### PR TITLE
implement pipeline expansion mechanism

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/PipelineExtensionWrapper.java
+++ b/src/main/java/com/corundumstudio/socketio/PipelineExtensionWrapper.java
@@ -1,0 +1,84 @@
+package com.corundumstudio.socketio;
+
+
+import io.netty.channel.ChannelHandler;
+
+/**
+ * Copyright 2012 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class PipelineExtensionWrapper {
+
+	public enum Mode {
+		ADD_FIRST,
+		ADD_BEFORE,
+		ADD_AFTER,
+		ADD_LAST;
+	}
+
+	private String name;
+	private Mode mode;
+	private String refName;
+	private ChannelHandler handler;
+
+	public PipelineExtensionWrapper(String name, Mode mode, String refN, ChannelHandler ch) {
+		setName(name);
+		setMode(mode);
+		setRefName(refN);
+		setHandler(ch);
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+
+		if (name == null || name.equalsIgnoreCase("")) {
+			throw new NullPointerException("name cannot be null or empty");
+		}
+
+		this.name = name;
+	}
+
+	public Mode getMode() {
+		return mode;
+	}
+
+	public void setMode(Mode mode) {
+		this.mode = mode;
+	}
+
+	public String getRefName() {
+		return refName;
+	}
+
+	public void setRefName(String refN) {
+		this.refName = refN;
+	}
+
+	public ChannelHandler getHandler() {
+		return handler;
+	}
+
+	public void setHandler(ChannelHandler handler) {
+
+		if (handler == null) {
+			throw new NullPointerException("handler object cannot be null");
+		}
+
+		this.handler = handler;
+	}
+}

--- a/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
@@ -15,15 +15,6 @@
  */
 package com.corundumstudio.socketio;
 
-import java.io.InputStream;
-import java.security.KeyStore;
-import java.security.Security;
-import java.util.Collection;
-
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
@@ -31,6 +22,17 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.ssl.SslHandler;
+
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,143 +56,171 @@ import com.corundumstudio.socketio.transport.XHRPollingTransport;
 
 public class SocketIOChannelInitializer extends ChannelInitializer<Channel> implements DisconnectableHub {
 
-    public static final String SOCKETIO_ENCODER = "socketioEncoder";
-    public static final String WEB_SOCKET_TRANSPORT = "webSocketTransport";
-    public static final String FLASH_SOCKET_TRANSPORT = "flashSocketTransport";
-    public static final String XHR_POLLING_TRANSPORT = "xhrPollingTransport";
-    public static final String AUTHORIZE_HANDLER = "authorizeHandler";
-    public static final String PACKET_HANDLER = "packetHandler";
-    public static final String HTTP_ENCODER = "encoder";
-    public static final String HTTP_AGGREGATOR = "aggregator";
-    public static final String HTTP_REQUEST_DECODER = "decoder";
-    public static final String SSL_HANDLER = "ssl";
-    public static final String FLASH_POLICY_HANDLER = "flashPolicyHandler";
-    public static final String RESOURCE_HANDLER = "resourceHandler";
+	public static final String SOCKETIO_ENCODER = "socketioEncoder";
+	public static final String WEB_SOCKET_TRANSPORT = "webSocketTransport";
+	public static final String FLASH_SOCKET_TRANSPORT = "flashSocketTransport";
+	public static final String XHR_POLLING_TRANSPORT = "xhrPollingTransport";
+	public static final String AUTHORIZE_HANDLER = "authorizeHandler";
+	public static final String PACKET_HANDLER = "packetHandler";
+	public static final String HTTP_ENCODER = "encoder";
+	public static final String HTTP_AGGREGATOR = "aggregator";
+	public static final String HTTP_REQUEST_DECODER = "decoder";
+	public static final String SSL_HANDLER = "ssl";
+	public static final String FLASH_POLICY_HANDLER = "flashPolicyHandler";
+	public static final String RESOURCE_HANDLER = "resourceHandler";
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+	private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private final int protocol = 1;
+	private final int protocol = 1;
 
-    private AckManager ackManager;
+	private AckManager ackManager;
 
-    private AuthorizeHandler authorizeHandler;
-    private XHRPollingTransport xhrPollingTransport;
-    private WebSocketTransport webSocketTransport;
-    private FlashSocketTransport flashSocketTransport;
-    private final FlashPolicyHandler flashPolicyHandler = new FlashPolicyHandler();
-    private ResourceHandler resourceHandler;
-    private SocketIOEncoder socketIOEncoder;
+	private AuthorizeHandler authorizeHandler;
+	private XHRPollingTransport xhrPollingTransport;
+	private WebSocketTransport webSocketTransport;
+	private FlashSocketTransport flashSocketTransport;
+	private final FlashPolicyHandler flashPolicyHandler = new FlashPolicyHandler();
+	private ResourceHandler resourceHandler;
+	private SocketIOEncoder socketIOEncoder;
 
-    private CancelableScheduler scheduler;
+	private CancelableScheduler scheduler;
 
-    private PacketHandler packetHandler;
-    private HeartbeatHandler heartbeatHandler;
-    private SSLContext sslContext;
-    private Configuration configuration;
+	private PacketHandler packetHandler;
+	private HeartbeatHandler heartbeatHandler;
+	private SSLContext sslContext;
+	private Configuration configuration;
 
-    public void start(Configuration configuration, NamespacesHub namespacesHub) {
-        this.configuration = configuration;
-        scheduler = new CancelableScheduler(configuration.getHeartbeatThreadPoolSize());
+	private final List<PipelineExtensionWrapper> pipelineExtensionList = new ArrayList<PipelineExtensionWrapper>();
 
-        ackManager = new AckManager(scheduler);
+	public void start(Configuration configuration, NamespacesHub namespacesHub) {
+		this.configuration = configuration;
+		scheduler = new CancelableScheduler(configuration.getHeartbeatThreadPoolSize());
 
-        JsonSupport jsonSupport = configuration.getJsonSupport();
-        Encoder encoder = new Encoder(configuration, jsonSupport);
-        Decoder decoder = new Decoder(jsonSupport, ackManager);
+		ackManager = new AckManager(scheduler);
 
-        heartbeatHandler = new HeartbeatHandler(configuration, scheduler);
-        PacketListener packetListener = new PacketListener(heartbeatHandler, ackManager, namespacesHub);
+		JsonSupport jsonSupport = configuration.getJsonSupport();
+		Encoder encoder = new Encoder(configuration, jsonSupport);
+		Decoder decoder = new Decoder(jsonSupport, ackManager);
 
-        String connectPath = configuration.getContext() + "/" + protocol + "/";
+		heartbeatHandler = new HeartbeatHandler(configuration, scheduler);
+		PacketListener packetListener = new PacketListener(heartbeatHandler, ackManager, namespacesHub);
 
-        boolean isSsl = configuration.getKeyStore() != null;
-        if (isSsl) {
-            try {
-                sslContext = createSSLContext(configuration.getKeyStore(), configuration.getKeyStorePassword());
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-        }
+		String connectPath = configuration.getContext() + "/" + protocol + "/";
 
-        packetHandler = new PacketHandler(packetListener, decoder, namespacesHub);
-        authorizeHandler = new AuthorizeHandler(connectPath, scheduler, configuration, namespacesHub);
-        xhrPollingTransport = new XHRPollingTransport(connectPath, ackManager, this, scheduler, authorizeHandler, configuration);
-        webSocketTransport = new WebSocketTransport(connectPath, isSsl, ackManager, this, authorizeHandler, heartbeatHandler);
-        flashSocketTransport = new FlashSocketTransport(connectPath, isSsl, ackManager, this, authorizeHandler, heartbeatHandler);
-        resourceHandler = new ResourceHandler(configuration.getContext());
-        socketIOEncoder = new SocketIOEncoder(encoder);
-    }
+		boolean isSsl = configuration.getKeyStore() != null;
+		if (isSsl) {
+			try {
+				sslContext = createSSLContext(configuration.getKeyStore(), configuration.getKeyStorePassword());
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+		}
 
-    public Collection<SocketIOClient> getAllClients() {
-        // TODO refactor to transport registry
-        Iterable<SocketIOClient> xhrClients = xhrPollingTransport.getAllClients();
-        Iterable<SocketIOClient> webSocketClients = webSocketTransport.getAllClients();
-        Iterable<SocketIOClient> flashSocketClients = flashSocketTransport.getAllClients();
-        CompositeIterable<SocketIOClient> mainIterable = new CompositeIterable<SocketIOClient>(xhrClients, webSocketClients, flashSocketClients);
-        return new IterableCollection<SocketIOClient>(mainIterable);
-    }
+		packetHandler = new PacketHandler(packetListener, decoder, namespacesHub);
+		authorizeHandler = new AuthorizeHandler(connectPath, scheduler, configuration, namespacesHub);
+		xhrPollingTransport = new XHRPollingTransport(connectPath, ackManager, this, scheduler, authorizeHandler, configuration);
+		webSocketTransport = new WebSocketTransport(connectPath, isSsl, ackManager, this, authorizeHandler, heartbeatHandler);
+		flashSocketTransport = new FlashSocketTransport(connectPath, isSsl, ackManager, this, authorizeHandler, heartbeatHandler);
+		resourceHandler = new ResourceHandler(configuration.getContext());
+		socketIOEncoder = new SocketIOEncoder(encoder);
+	}
 
-    @Override
-    protected void initChannel(Channel ch) throws Exception {
-        ChannelPipeline pipeline = ch.pipeline();
-        boolean isFlashTransport = configuration.getTransports().contains(FlashSocketTransport.NAME);
-        if (isFlashTransport) {
-            pipeline.addLast(FLASH_POLICY_HANDLER, flashPolicyHandler);
-        }
+	public Collection<SocketIOClient> getAllClients() {
+		// TODO refactor to transport registry
+		Iterable<SocketIOClient> xhrClients = xhrPollingTransport.getAllClients();
+		Iterable<SocketIOClient> webSocketClients = webSocketTransport.getAllClients();
+		Iterable<SocketIOClient> flashSocketClients = flashSocketTransport.getAllClients();
+		CompositeIterable<SocketIOClient> mainIterable = new CompositeIterable<SocketIOClient>(xhrClients, webSocketClients, flashSocketClients);
+		return new IterableCollection<SocketIOClient>(mainIterable);
+	}
 
-        if (sslContext != null) {
-            SSLEngine engine = sslContext.createSSLEngine();
-            engine.setUseClientMode(false);
-            pipeline.addLast(SSL_HANDLER, new SslHandler(engine));
-        }
+	@Override
+	protected void initChannel(Channel ch) throws Exception {
+		ChannelPipeline pipeline = ch.pipeline();
+		boolean isFlashTransport = configuration.getTransports().contains(FlashSocketTransport.NAME);
+		if (isFlashTransport) {
+			pipeline.addLast(FLASH_POLICY_HANDLER, flashPolicyHandler);
+		}
 
-        pipeline.addLast(HTTP_REQUEST_DECODER, new HttpRequestDecoder());
-        pipeline.addLast(HTTP_AGGREGATOR, new HttpObjectAggregator(configuration.getMaxHttpContentLength()));
-        pipeline.addLast(HTTP_ENCODER, new HttpResponseEncoder());
+		if (sslContext != null) {
+			SSLEngine engine = sslContext.createSSLEngine();
+			engine.setUseClientMode(false);
+			pipeline.addLast(SSL_HANDLER, new SslHandler(engine));
+		}
 
-        if (isFlashTransport) {
-            pipeline.addLast(RESOURCE_HANDLER, resourceHandler);
-        }
-        pipeline.addLast(PACKET_HANDLER, packetHandler);
+		pipeline.addLast(HTTP_REQUEST_DECODER, new HttpRequestDecoder());
+		pipeline.addLast(HTTP_AGGREGATOR, new HttpObjectAggregator(configuration.getMaxHttpContentLength()));
+		pipeline.addLast(HTTP_ENCODER, new HttpResponseEncoder());
 
-        pipeline.addLast(AUTHORIZE_HANDLER, authorizeHandler);
-        pipeline.addLast(XHR_POLLING_TRANSPORT, xhrPollingTransport);
-        pipeline.addLast(WEB_SOCKET_TRANSPORT, webSocketTransport);
-        pipeline.addLast(FLASH_SOCKET_TRANSPORT, flashSocketTransport);
+		if (isFlashTransport) {
+			pipeline.addLast(RESOURCE_HANDLER, resourceHandler);
+		}
+		pipeline.addLast(PACKET_HANDLER, packetHandler);
 
-        pipeline.addLast(SOCKETIO_ENCODER, socketIOEncoder);
-    }
+		pipeline.addLast(AUTHORIZE_HANDLER, authorizeHandler);
+		pipeline.addLast(XHR_POLLING_TRANSPORT, xhrPollingTransport);
+		pipeline.addLast(WEB_SOCKET_TRANSPORT, webSocketTransport);
+		pipeline.addLast(FLASH_SOCKET_TRANSPORT, flashSocketTransport);
 
-    private SSLContext createSSLContext(InputStream keyStoreFile, String keyStoreFilePassword) throws Exception {
-        String algorithm = Security.getProperty("ssl.KeyManagerFactory.algorithm");
-        if (algorithm == null) {
-            algorithm = "SunX509";
-        }
+		pipeline.addLast(SOCKETIO_ENCODER, socketIOEncoder);
 
-        KeyStore ks = KeyStore.getInstance("JKS");
-        ks.load(keyStoreFile, keyStoreFilePassword.toCharArray());
+		for (PipelineExtensionWrapper extensionWrapper : pipelineExtensionList) {
 
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
-        kmf.init(ks, keyStoreFilePassword.toCharArray());
+			try {
+				switch (extensionWrapper.getMode()) {
+				case ADD_FIRST:
+					pipeline.addFirst(extensionWrapper.getHandler());
+					break;
+				case ADD_BEFORE:
+					pipeline.addBefore(extensionWrapper.getRefName(), extensionWrapper.getName(), extensionWrapper.getHandler());
+					break;
+				case ADD_AFTER:
+					pipeline.addAfter(extensionWrapper.getRefName(), extensionWrapper.getName(), extensionWrapper.getHandler());
+					break;
+				case ADD_LAST:
+					pipeline.addLast(extensionWrapper.getHandler());
+					break;
+				}
+			} catch (Exception e) {
+				log.error("Failed to add {} handler to the pipeline.", extensionWrapper.getName(), e);
+			}
+		}
+	}
 
-        SSLContext serverContext = SSLContext.getInstance("TLS");
-        serverContext.init(kmf.getKeyManagers(), null, null);
-        return serverContext;
-    }
+	private SSLContext createSSLContext(InputStream keyStoreFile, String keyStoreFilePassword) throws Exception {
+		String algorithm = Security.getProperty("ssl.KeyManagerFactory.algorithm");
+		if (algorithm == null) {
+			algorithm = "SunX509";
+		}
 
-    public void onDisconnect(BaseClient client) {
-        heartbeatHandler.onDisconnect(client);
-        ackManager.onDisconnect(client);
-        xhrPollingTransport.onDisconnect(client);
-        webSocketTransport.onDisconnect(client);
-        flashSocketTransport.onDisconnect(client);
-        authorizeHandler.onDisconnect(client);
-        socketIOEncoder.onDisconnect(client);
-        log.debug("Client with sessionId: {} disconnected", client.getSessionId());
-    }
+		KeyStore ks = KeyStore.getInstance("JKS");
+		ks.load(keyStoreFile, keyStoreFilePassword.toCharArray());
 
-    public void stop() {
-        scheduler.shutdown();
-    }
+		KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
+		kmf.init(ks, keyStoreFilePassword.toCharArray());
 
+		SSLContext serverContext = SSLContext.getInstance("TLS");
+		serverContext.init(kmf.getKeyManagers(), null, null);
+		return serverContext;
+	}
+
+	@Override
+	public void onDisconnect(BaseClient client) {
+		heartbeatHandler.onDisconnect(client);
+		ackManager.onDisconnect(client);
+		xhrPollingTransport.onDisconnect(client);
+		webSocketTransport.onDisconnect(client);
+		flashSocketTransport.onDisconnect(client);
+		authorizeHandler.onDisconnect(client);
+		socketIOEncoder.onDisconnect(client);
+		log.debug("Client with sessionId: {} disconnected", client.getSessionId());
+	}
+
+	public List<PipelineExtensionWrapper> getExtensionList(){
+		return pipelineExtensionList;
+	}
+
+	public void stop() {
+		scheduler.shutdown();
+	}
 }


### PR DESCRIPTION
I have implemented a pipeline expansion mechanism which is flexible and doesn't modify the framework logic flow. I think that pipeline customization freedom is needed in this framework because such freedom only adds great power to it and its usage isn't forced on anyone.

An use case would be adding a static file handler for compact interface serving or any other useful handler avoiding the need to instantiate another server or web container.

The pipeline customization is really easy with this method:

```
SocketIOChannelInitializer pipelineFactory = server.getPipelineFactory();
PipelineExtensionWrapper pexw = new PipelineExtensionWrapper("HttpStaticHandler", Mode.ADD_BEFORE, SocketIOChannelInitializer.PACKET_HANDLER, new HttpServerHandler(true));
pipelineFactory.getExtensionList().add(pexw);
```
