### PR TITLE
Added release of byte buffer in PacketEncoder.java

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketEncoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketEncoder.java
@@ -264,15 +264,20 @@ public class PacketEncoder {
                         if (binary) {
                             // handling websocket encoding bug
                             ByteBuf b = allocateBuffer(allocator);
-                            ByteBufOutputStream os = new ByteBufOutputStream(b);
-                            jsonSupport.writeValue(os, values);
+                            try {
+                                ByteBufOutputStream os = new ByteBufOutputStream(b);
+                                jsonSupport.writeValue(os, values);
 
-                            CharsetEncoder enc = CharsetUtil.ISO_8859_1.newEncoder();
-                            String str = b.toString(CharsetUtil.ISO_8859_1);
-                            if (enc.canEncode(str)) {
-                                buf.writeBytes(str.getBytes(CharsetUtil.UTF_8));
-                            } else {
-                                buf.writeBytes(b);
+                                CharsetEncoder enc = CharsetUtil.ISO_8859_1.newEncoder();
+                                String str = b.toString(CharsetUtil.ISO_8859_1);
+                                if (enc.canEncode(str)) {
+                                    buf.writeBytes(str.getBytes(CharsetUtil.UTF_8));
+                                } else {
+                                    buf.writeBytes(b);
+                                }
+                            }
+                            finally {
+                                b.release();
                             }
                         } else {
                             jsonSupport.writeValue(out, values);


### PR DESCRIPTION
Hi,

I was running the new 1.7.2 version in our performance tests env and keep getting a netty resource leak (See stack trace). I added a fix for the leak and thought you might wan't to take a look at it. 

With 1.7.2 I get the error almost instantly when we have ~100 clients, but with the fix we can't reproduce the leak.

Please have a look at it.
Thanks.

2014-08-28 12:50:56,631 [ERROR](pGroup-3-2) io.netty.util.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before it's garbage-collected.
Recent access records: 2
#2:

```
io.netty.buffer.AdvancedLeakAwareByteBuf.toString(AdvancedLeakAwareByteBuf.java:697)
com.corundumstudio.socketio.protocol.PacketEncoder.encodePacket(PacketEncoder.java:271)
com.corundumstudio.socketio.handler.EncoderHandler.handleWebsocket(EncoderHandler.java:212)
com.corundumstudio.socketio.handler.EncoderHandler.write(EncoderHandler.java:191)
io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:658)
io.netty.channel.AbstractChannelHandlerContext.access$2000(AbstractChannelHandlerContext.java:32)
io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask.write(AbstractChannelHandlerContext.java:939)
io.netty.channel.AbstractChannelHandlerContext$WriteAndFlushTask.write(AbstractChannelHandlerContext.java:991)
io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask.run(AbstractChannelHandlerContext.java:924)
io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:380)
io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:357)
io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116)
io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
java.lang.Thread.run(Thread.java:744)
```
#1:

```
io.netty.buffer.AdvancedLeakAwareByteBuf.writeBytes(AdvancedLeakAwareByteBuf.java:571)
io.netty.buffer.ByteBufOutputStream.write(ByteBufOutputStream.java:66)
com.fasterxml.jackson.core.json.UTF8JsonGenerator._flushBuffer(UTF8JsonGenerator.java:1862)
com.fasterxml.jackson.core.json.UTF8JsonGenerator.close(UTF8JsonGenerator.java:1087)
com.fasterxml.jackson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:2720)
com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:2177)
com.corundumstudio.socketio.protocol.JacksonJsonSupport.writeValue(JacksonJsonSupport.java:234)
com.corundumstudio.socketio.JsonSupportWrapper.writeValue(JsonSupportWrapper.java:69)
com.corundumstudio.socketio.protocol.PacketEncoder.encodePacket(PacketEncoder.java:268)
com.corundumstudio.socketio.handler.EncoderHandler.handleWebsocket(EncoderHandler.java:212)
com.corundumstudio.socketio.handler.EncoderHandler.write(EncoderHandler.java:191)
io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:658)
io.netty.channel.AbstractChannelHandlerContext.access$2000(AbstractChannelHandlerContext.java:32)
io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask.write(AbstractChannelHandlerContext.java:939)
io.netty.channel.AbstractChannelHandlerContext$WriteAndFlushTask.write(AbstractChannelHandlerContext.java:991)
io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask.run(AbstractChannelHandlerContext.java:924)
io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:380)
io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:357)
io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116)
io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
java.lang.Thread.run(Thread.java:744)
```

Created at:
    io.netty.buffer.UnpooledByteBufAllocator.newDirectBuffer(UnpooledByteBufAllocator.java:55)
    io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:155)
    io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:146)
    io.netty.buffer.AbstractByteBufAllocator.ioBuffer(AbstractByteBufAllocator.java:99)
    com.corundumstudio.socketio.protocol.PacketEncoder.allocateBuffer(PacketEncoder.java:51)
    com.corundumstudio.socketio.protocol.PacketEncoder.encodePacket(PacketEncoder.java:266)
    com.corundumstudio.socketio.handler.EncoderHandler.handleWebsocket(EncoderHandler.java:212)
    com.corundumstudio.socketio.handler.EncoderHandler.write(EncoderHandler.java:191)
    io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:658)
    io.netty.channel.AbstractChannelHandlerContext.access$2000(AbstractChannelHandlerContext.java:32)
    io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask.write(AbstractChannelHandlerContext.java:939)
    io.netty.channel.AbstractChannelHandlerContext$WriteAndFlushTask.write(AbstractChannelHandlerContext.java:991)
    io.netty.channel.AbstractChannelHandlerContext$AbstractWriteTask.run(AbstractChannelHandlerContext.java:924)
    io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:380)
    io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:357)
    io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116)
    io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
    java.lang.Thread.run(Thread.java:744)
