### PR TITLE
Update EncoderHandler.java

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/handler/EncoderHandler.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/EncoderHandler.java
@@ -177,7 +177,7 @@ public class EncoderHandler extends ChannelOutboundHandlerAdapter {
                 HttpHeaders.addHeader(res, ACCESS_CONTROL_ALLOW_CREDENTIALS, Boolean.TRUE);
             } else {
                 HttpHeaders.addHeader(res, ACCESS_CONTROL_ALLOW_ORIGIN, "*");
-                HttpHeaders.addHeader(res, ACCESS_CONTROL_ALLOW_CREDENTIALS, Boolean.TRUE);
+                HttpHeaders.addHeader(res, ACCESS_CONTROL_ALLOW_CREDENTIALS, Boolean.FALSE);
             }
         }
     }


### PR DESCRIPTION
I get an error message from Chrome that wildcards are not allowed in ACCESS_CONTROL_ALLOW_ORIGIN when ACCESS_CONTROL_ALLOW_CREDENTIALS is true.