### PR TITLE
Changed how clientRooms map is cleaned up after a client leaves

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
+++ b/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
@@ -299,7 +299,7 @@ public class Namespace implements SocketIONamespace {
 
     public void leave(String room, UUID sessionId) {
         leave(roomClients, room, sessionId);
-        leave(clientRooms, sessionId, room);
+        clientRooms.remove(sessionId);
     }
 
     public Set<String> getRooms(SocketIOClient client) {


### PR DESCRIPTION
It should be removed from the map even if the client was connected to one or more rooms before disconnecting. 
Otherwise the entry will stay in memory, causing a memory leak. 

The "leave" method still makes sense for roomClients, since we don't want to delete from that map util nobody is interested in the room anymore. This leak only applies to clientRooms.
We have verified by checking how the sizes of these maps grows during frequent connect / disconnects. 