### PR TITLE
SessionID cookie implementation, and expose the rooms?

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
+++ b/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
@@ -310,6 +310,10 @@ public class Namespace implements SocketIONamespace {
         return Collections.unmodifiableSet(res);
     }
 
+    public Set<String> getRooms() {
+        return roomClients.keySet();
+    }
+
     public Iterable<SocketIOClient> getRoomClients(String room) {
         Set<UUID> sessionIds = roomClients.get(room);
 


### PR DESCRIPTION
Added a simple method to get all the rooms for a single namespace.
Added the ability to use the "io" cookie for the sessionId if it is present.

If there is an existing way to "list all rooms" for a given namespace, I didn't see it.  Basically I want to be able to do the following.

1. List all the namespaces.
2. List all the clients for a given namespace.
3. List all the rooms for a given namespace.
4. List all the clients in each room.

All seem in reach with the current code except the third one.  The code written seems to expose that without too much trouble.  Thoughts?