### PR TITLE
Code quality fix - Methods named "equals" should override Object.equals(Object)

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/annotation/ScannerEngine.java
+++ b/src/main/java/com/corundumstudio/socketio/annotation/ScannerEngine.java
@@ -36,7 +36,7 @@ public class ScannerEngine {
     private Method findSimilarMethod(Class<?> objectClazz, Method method) {
         Method[] methods = objectClazz.getDeclaredMethods();
         for (Method m : methods) {
-            if (equals(m, method)) {
+            if (isEquals(m, method)) {
                 return m;
             }
         }
@@ -86,7 +86,7 @@ public class ScannerEngine {
 
     }
 
-    private boolean equals(Method method1, Method method2) {
+    private boolean isEquals(Method method1, Method method2) {
         if (!method1.getName().equals(method2.getName())
                 || !method1.getReturnType().equals(method2.getReturnType())) {
             return false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:S1201 - Methods named "equals" should override Object.equals(Object)

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S1201

Please let me know if you have any questions.

Faisal