### PR TITLE
Single quotes are not valid Java String delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Declarative handlers binding. Handlers could be bound via annotations on any obj
              ...
 
              // SocketIOClient, AckRequest and Data could be ommited
-             @OnEvent('someevent')
+             @OnEvent("someevent")
              public void onSomeEventHandler(SocketIOClient client, SomeClass data, AckRequest ackRequest) {
                  ...
              }


### PR DESCRIPTION
Just a minor typo in the README.