### PR TITLE
Update PacketDecoder.java

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
@@ -65,12 +65,6 @@ public class PacketDecoder {
             */
             packet = packet.replace("\\\\n", "\\n");
         }
-
-        int splitIndex = packet.indexOf(":");
-        String len = packet.substring(startPos, splitIndex);
-        Integer length = Integer.valueOf(len);
-
-        packet = packet.substring(splitIndex+1, splitIndex+length+1);
         packet = new String(packet.getBytes(CharsetUtil.ISO_8859_1), CharsetUtil.UTF_8);
 
         return Unpooled.wrappedBuffer(packet.getBytes(CharsetUtil.UTF_8));


### PR DESCRIPTION
FIX for: Polling clients sporatically get prematurely disconnected #264
The issue is piggy-backed messages are getting dropped on polling, The code I removed was simply taking the 1st message and dropping the rest.
Part of that rest could've been an Pong or Ping (as well as other data), and thus causes the dropping of the polling client connection.