### PR TITLE
Bug fix - IllegalStateException thrown on valid binary packet when placeholder fields in opposite order

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
@@ -252,7 +252,11 @@ public class PacketDecoder {
                     ByteBuf scanValue = Unpooled.copiedBuffer("{\"_placeholder\":true,\"num\":" + i + "}", CharsetUtil.UTF_8);
                     int pos = PacketEncoder.find(source, scanValue);
                     if (pos == -1) {
-                        throw new IllegalStateException("Can't find attachment by index: " + i + " in packet source");
+                        scanValue = Unpooled.copiedBuffer("{\"num\":" + i + ",\"_placeholder\":true}", CharsetUtil.UTF_8);
+                        pos = PacketEncoder.find(source, scanValue);
+                        if (pos == -1) {
+                            throw new IllegalStateException("Can't find attachment by index: " + i + " in packet source");
+                        }
                     }
 
                     ByteBuf prefixBuf = source.slice(source.readerIndex(), pos - source.readerIndex());


### PR DESCRIPTION
Fix in src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java:

Fix parsing of binary packets in the case where the binary member's placeholder object contains the num and _placeholder members in the opposite order (num, _placeholder instead of _placeholder, num).

Some socket.io clients do this and it's valid.