### PR TITLE
Bug when using leaveRoom

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
+++ b/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
@@ -301,7 +301,7 @@ public class Namespace implements SocketIONamespace {
 
     public void leave(String room, UUID sessionId) {
         leave(roomClients, room, sessionId);
-        clientRooms.remove(sessionId);
+        leave(clientRooms, sessionId, room);
     }
 
     public Set<String> getRooms(SocketIOClient client) {

--- a/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
+++ b/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
@@ -175,6 +175,11 @@ public class Namespace implements SocketIONamespace {
         leave(getName(), client.getSessionId());
         storeFactory.pubSubStore().publish(PubSubType.LEAVE, new JoinLeaveMessage(client.getSessionId(), getName(), getName()));
 
+        for (String joinedRoom : joinedRooms) {
+            leave(roomClients, joinedRoom, client.getSessionId());
+        }
+        clientRooms.remove(client.getSessionId());
+
         try {
             for (DisconnectListener listener : disconnectListeners) {
                 listener.onDisconnect(client);


### PR DESCRIPTION
When using leaveRoom, the complete clientRooms Instance get removed, which causes the SocketIOClient getAllRooms Method to returns a empty list, even when your client is still in some rooms. This doesn't harm SocketIOServer getRoomOperations Method (which still returns all clients from the given room), but harms for example the onDisconnectListener, when you override the onDisconnect Method, which than returns a empty list for the joinedRooms.