### PR TITLE
adding option for custom executor

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/Configuration.java
+++ b/src/main/java/com/corundumstudio/socketio/Configuration.java
@@ -18,6 +18,7 @@ package com.corundumstudio.socketio;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 import com.corundumstudio.socketio.handler.SuccessAuthorizationListener;
 import com.corundumstudio.socketio.listener.DefaultExceptionListener;
@@ -81,6 +82,8 @@ public class Configuration {
     private boolean httpCompression = true;
 
     private boolean websocketCompression = true;
+
+    private Executor executor = null;
 
     public Configuration() {
     }
@@ -146,6 +149,8 @@ public class Configuration {
 
         setHttpCompression(conf.isHttpCompression());
         setWebsocketCompression(conf.isWebsocketCompression());
+
+        setExecutor(conf.getExecutor());
     }
 
     public JsonSupport getJsonSupport() {
@@ -561,4 +566,11 @@ public class Configuration {
         return websocketCompression;
     }
 
+    public Executor getExecutor() {
+        return executor;
+    }
+
+    public void setExecutor(Executor executor) {
+        this.executor = executor;
+    }
 }

--- a/src/main/java/com/corundumstudio/socketio/SocketIOServer.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOServer.java
@@ -15,6 +15,21 @@
  */
 package com.corundumstudio.socketio;
 
+import com.corundumstudio.socketio.listener.ClientListeners;
+import com.corundumstudio.socketio.listener.ConnectListener;
+import com.corundumstudio.socketio.listener.DataListener;
+import com.corundumstudio.socketio.listener.DisconnectListener;
+import com.corundumstudio.socketio.listener.MultiTypeEventListener;
+import com.corundumstudio.socketio.namespace.Namespace;
+import com.corundumstudio.socketio.namespace.NamespacesHub;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.UUID;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -26,21 +41,6 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
-
-import java.net.InetSocketAddress;
-import java.util.Collection;
-import java.util.UUID;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.corundumstudio.socketio.listener.ClientListeners;
-import com.corundumstudio.socketio.listener.ConnectListener;
-import com.corundumstudio.socketio.listener.DataListener;
-import com.corundumstudio.socketio.listener.DisconnectListener;
-import com.corundumstudio.socketio.listener.MultiTypeEventListener;
-import com.corundumstudio.socketio.namespace.Namespace;
-import com.corundumstudio.socketio.namespace.NamespacesHub;
 
 /**
  * Fully thread-safe.
@@ -179,11 +179,11 @@ public class SocketIOServer implements ClientListeners {
 
     protected void initGroups() {
         if (configCopy.isUseLinuxNativeEpoll()) {
-            bossGroup = new EpollEventLoopGroup(configCopy.getBossThreads());
-            workerGroup = new EpollEventLoopGroup(configCopy.getWorkerThreads());
+            bossGroup = new EpollEventLoopGroup(configCopy.getBossThreads(), configCopy.getExecutor());
+            workerGroup = new EpollEventLoopGroup(configCopy.getWorkerThreads(), configCopy.getExecutor());
         } else {
-            bossGroup = new NioEventLoopGroup(configCopy.getBossThreads());
-            workerGroup = new NioEventLoopGroup(configCopy.getWorkerThreads());
+            bossGroup = new NioEventLoopGroup(configCopy.getBossThreads(), configCopy.getExecutor());
+            workerGroup = new NioEventLoopGroup(configCopy.getWorkerThreads(), configCopy.getExecutor());
         }
     }
 


### PR DESCRIPTION
This allows library user to choose what executor to use for the server.
In my case, my application makes sure that there are only 2 pools default FJP and one IO thread pool (which has lots of custom telemetry and other custom logic). Most importantly it ensures that there is only one non daemon thread (main thread) everything else is daemon hence when main thread is finished all the resource deallocation tasks which were previously scheduled to Runtime.shutDownHook()... will execute and application will shut down gracefully. 

However if i use this library i will end up having another main method, which prevents application from shutting down. For libraries like this i think its important to give option to choose what executors are being used etc...

This change adds option to provide custom executor to Configuration, which will be used to create netty event loop groups...  