### PR TITLE
Allow authorizing channels which are connected through LocalAddress

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/HandshakeData.java
+++ b/src/main/java/com/corundumstudio/socketio/HandshakeData.java
@@ -17,6 +17,7 @@ package com.corundumstudio.socketio;
 
 import java.io.Serializable;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,7 @@ public class HandshakeData implements Serializable {
     private static final long serialVersionUID = 1196350300161819978L;
 
     private Map<String, List<String>> headers;
-    private InetSocketAddress address;
+    private SocketAddress address;
     private Date time = new Date();
     private String url;
     private Map<String, List<String>> urlParams;
@@ -35,7 +36,7 @@ public class HandshakeData implements Serializable {
     public HandshakeData() {
     }
 
-    public HandshakeData(Map<String, List<String>> headers, Map<String, List<String>> urlParams, InetSocketAddress address, String url, boolean xdomain) {
+    public HandshakeData(Map<String, List<String>> headers, Map<String, List<String>> urlParams, SocketAddress address, String url, boolean xdomain) {
         super();
         this.headers = headers;
         this.urlParams = urlParams;
@@ -44,9 +45,17 @@ public class HandshakeData implements Serializable {
         this.xdomain = xdomain;
     }
 
-    public InetSocketAddress getAddress() {
-        return address;
-    }
+	/**
+	 * @deprecated use {@link #getSocketAddress()} instead
+	 */
+	@Deprecated
+	public InetSocketAddress getAddress() {
+		return (InetSocketAddress) address;
+	}
+
+	public SocketAddress getSocketAddress() {
+		return address;
+	}
 
     public Map<String, List<String>> getHeaders() {
         return headers;

--- a/src/main/java/com/corundumstudio/socketio/handler/AuthorizeHandler.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/AuthorizeHandler.java
@@ -30,7 +30,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.QueryStringDecoder;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -129,7 +128,7 @@ public class AuthorizeHandler extends ChannelInboundHandlerAdapter implements Di
         }
 
         HandshakeData data = new HandshakeData(headers, params,
-                                                (InetSocketAddress)channel.remoteAddress(),
+                                                channel.remoteAddress(),
                                                     req.getUri(), origin != null && !origin.equalsIgnoreCase("null"));
 
         boolean result = false;


### PR DESCRIPTION
Local addresses (io.netty.channel.local.LocalAddress) are quite useful as they don't bind to real socket address are less likely to cause unwanted side-effects with other processes for integration tests and unit tests.
Authorization for socket io clients connecting through local address failed because HandshakeData data was expecting instance of InetSocketAddress.
