### PR TITLE
Added option to change the SSL KeyManagerFactoryAlgorithm using Configuration.

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/Configuration.java
+++ b/src/main/java/com/corundumstudio/socketio/Configuration.java
@@ -26,6 +26,8 @@ import com.corundumstudio.socketio.protocol.JsonSupport;
 import com.corundumstudio.socketio.store.MemoryStoreFactory;
 import com.corundumstudio.socketio.store.StoreFactory;
 
+import javax.net.ssl.KeyManagerFactory;
+
 public class Configuration {
 
     private ExceptionListener exceptionListener = new DefaultExceptionListener();
@@ -62,6 +64,8 @@ public class Configuration {
     private InputStream trustStore;
     private String trustStorePassword;
 
+    private String keyManagerFactoryAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
+
     private boolean preferDirectBuffer = true;
 
     private SocketConfig socketConfig = new SocketConfig();
@@ -88,7 +92,7 @@ public class Configuration {
     /**
      * Defend from further modifications by cloning
      *
-     * @param configuration - Configuration object to clone
+     * @param conf - Configuration object to clone
      */
     Configuration(Configuration conf) {
         setBossThreads(conf.getBossThreads());
@@ -126,6 +130,7 @@ public class Configuration {
         setTrustStore(conf.getTrustStore());
         setTrustStoreFormat(conf.getTrustStoreFormat());
         setTrustStorePassword(conf.getTrustStorePassword());
+        setKeyManagerFactoryAlgorithm(conf.getKeyManagerFactoryAlgorithm());
 
         setTransports(conf.getTransports().toArray(new Transport[conf.getTransports().size()]));
         setMaxHttpContentLength(conf.getMaxHttpContentLength());
@@ -202,7 +207,7 @@ public class Configuration {
     /**
      * Ping interval
      *
-     * @param value - time in milliseconds
+     * @param heartbeatIntervalSecs - time in milliseconds
      */
     public void setPingInterval(int heartbeatIntervalSecs) {
         this.pingInterval = heartbeatIntervalSecs;
@@ -215,7 +220,7 @@ public class Configuration {
      * Ping timeout
      * Use <code>0</code> to disable it
      *
-     * @param value - time in milliseconds
+     * @param heartbeatTimeoutSecs - time in milliseconds
      */
     public void setPingTimeout(int heartbeatTimeoutSecs) {
         this.pingTimeout = heartbeatTimeoutSecs;
@@ -289,7 +294,7 @@ public class Configuration {
     /**
      * Set maximum http content length limit
      *
-     * @param maxContentLength
+     * @param value
      *        the maximum length of the aggregated http content.
      */
     public void setMaxHttpContentLength(int value) {
@@ -351,7 +356,7 @@ public class Configuration {
      * Data store - used to store session data and implements distributed pubsub.
      * Default is {@code MemoryStoreFactory}
      *
-     * @param storeFactory - implements StoreFactory
+     * @param clientStoreFactory - implements StoreFactory
      *
      * @see com.corundumstudio.socketio.store.MemoryStoreFactory
      * @see com.corundumstudio.socketio.store.RedissonStoreFactory
@@ -443,6 +448,14 @@ public class Configuration {
     public void setTrustStorePassword(String trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
     }
+
+    public String getKeyManagerFactoryAlgorithm() {
+        return keyManagerFactoryAlgorithm;
+    }
+    public void setKeyManagerFactoryAlgorithm(String keyManagerFactoryAlgorithm) {
+        this.keyManagerFactoryAlgorithm = keyManagerFactoryAlgorithm;
+    }
+
 
     /**
      * Set maximum websocket frame content length limit

--- a/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
@@ -208,7 +208,7 @@ public class SocketIOChannelInitializer extends ChannelInitializer<Channel> impl
         KeyStore ks = KeyStore.getInstance(configuration.getKeyStoreFormat());
         ks.load(configuration.getKeyStore(), configuration.getKeyStorePassword().toCharArray());
 
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(configuration.getKeyManagerFactoryAlgorithm());
         kmf.init(ks, configuration.getKeyStorePassword().toCharArray());
 
         SSLContext serverContext = SSLContext.getInstance(configuration.getSSLProtocol());


### PR DESCRIPTION
The SSLContext setup retrieved most of its parameters from Configuration, except the algorithm for KeyManagerFactory, for which it used only the default one.

I have added this setting to the Configuration file and updated the SSLContext building accordingly. 

Also fixed some javadoc @param inconsistencies.