### PR TITLE
Add support for BINARY_ACK(6, true) packet, which is used when the ar…

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/handler/PacketListener.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/PacketListener.java
@@ -89,7 +89,8 @@ public class PacketListener {
                 client.getBaseClient().send(packet, transport);
             }
 
-            if (packet.getSubType() == PacketType.ACK) {
+            if (packet.getSubType() == PacketType.ACK
+                    || packet.getSubType() == PacketType.BINARY_ACK) {
                 ackManager.onAck(client, packet);
             }
 

--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketEncoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketEncoder.java
@@ -280,7 +280,8 @@ public class PacketEncoder {
                             for (byte[] array : jsonSupport.getArrays()) {
                                 packet.addAttachment(Unpooled.wrappedBuffer(array));
                             }
-                            packet.setSubType(PacketType.BINARY_EVENT);
+                            packet.setSubType(packet.getSubType() == PacketType.ACK
+                                    ? PacketType.BINARY_ACK : PacketType.BINARY_EVENT);
                         }
                     }
 

--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketType.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketType.java
@@ -20,7 +20,7 @@ public enum PacketType {
 
     OPEN(0), CLOSE(1), PING(2), PONG(3), MESSAGE(4), UPGRADE(5), NOOP(6),
 
-    CONNECT(0, true), DISCONNECT(1, true), EVENT(2, true), ACK(3, true), ERROR(4, true), BINARY_EVENT(5, true);
+    CONNECT(0, true), DISCONNECT(1, true), EVENT(2, true), ACK(3, true), ERROR(4, true), BINARY_EVENT(5, true), BINARY_ACK(6, true);
 
     public static final PacketType[] VALUES = values();
     private final int value;


### PR DESCRIPTION
Add support for BINARY_ACK(6, true) packet, which is used when the arguments for an ACK function contain binary data; encodes packet in the BINARY_EVENT style documented in https://github.com/socketio/socket.io-protocol.
Without BINARY_ACK on the server sending an object with a binary field doesn't trigger ack listener on the client, which breaks handling logic.