### PR TITLE
fix for issue #402, marking channel promise as success twice

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/handler/EncoderHandler.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/EncoderHandler.java
@@ -227,7 +227,9 @@ public class EncoderHandler extends ChannelOutboundHandlerAdapter {
             Queue<Packet> queue = msg.getClientHead().getPacketsQueue(msg.getTransport());
             Packet packet = queue.poll();
             if (packet == null) {
-                promise.trySuccess();
+                if (!promise.isDone()) {
+                    promise.trySuccess();
+                }
                 break;
             }
 


### PR DESCRIPTION
As discussed in issue #402, I was getting the following messages: 

`WARNING: Failed to mark a promise as success because it has succeeded already: DefaultChannelPromise`

I was using the io.socket:socket.io-client:1.0.0 java client to produce these error messages.

I have tracked it down to the line marked below (by creating a patched Netty library, which logged the stack trace in detail) and applied a fix similar to commit 74234cec750427a773cb5bcecbc831f3515c6340

After applying this fix the warnings ceased.