### PR TITLE
Set version of netty-transport to 4.1.15.Final as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
   <dependency>
   	<groupId>io.netty</groupId>
   	<artifactId>netty-transport</artifactId>
-  	<version>4.1.5.Final</version>
+       <version>4.1.15.Final</version>
   </dependency>
   <dependency>
   	<groupId>io.netty</groupId>


### PR DESCRIPTION
I had a java.lang.NoSuchMethodError: io.netty.util.internal.PlatformDependent.newAtomicIntegerFieldUpdater because of conflicting netty versions.
This pr updates the old(maybe forgotten) netty dependencies to 4.1.15.Final.