### PR TITLE
Support for slow client

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/BroadcastOperations.java
+++ b/src/main/java/com/corundumstudio/socketio/BroadcastOperations.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.corundumstudio.socketio.misc.IterableCollection;
 import com.corundumstudio.socketio.namespace.Namespace;
@@ -71,11 +72,13 @@ public class BroadcastOperations implements ClientOperations {
     }
 
     @Override
-    public void send(Packet packet) {
+    public NetworkCallback<? extends Void> send(Packet packet) {
         for (SocketIOClient client : clients) {
             client.send(packet);
         }
         dispatch(packet);
+
+        return NetworkCallbacks.success(null);
     }
 
     public <T> void send(Packet packet, BroadcastAckCallback<T> ackCallback) {
@@ -106,14 +109,14 @@ public class BroadcastOperations implements ClientOperations {
         }
         dispatch(packet);
     }
-    
+
     @Override
-    public void sendEvent(String name, Object... data) {
+    public NetworkCallback<? extends Void> sendEvent(String name, Object... data) {
         Packet packet = new Packet(PacketType.MESSAGE);
         packet.setSubType(PacketType.EVENT);
         packet.setName(name);
         packet.setData(Arrays.asList(data));
-        send(packet);
+        return send(packet);
     }
 
     public <T> void sendEvent(String name, Object data, BroadcastAckCallback<T> ackCallback) {

--- a/src/main/java/com/corundumstudio/socketio/NetworkCallback.java
+++ b/src/main/java/com/corundumstudio/socketio/NetworkCallback.java
@@ -15,34 +15,12 @@
  */
 package com.corundumstudio.socketio;
 
-import com.corundumstudio.socketio.protocol.Packet;
+import java.util.concurrent.Future;
 
 /**
- * Available client operations
- *
+ * Callback for the network operations.
  */
-public interface ClientOperations {
-
-    /**
-     * Send custom packet.
-     * But {@link ClientOperations#sendEvent} method
-     * usage is enough for most cases.
-     *
-     * @param packet - packet to send
-     */
-    NetworkCallback<? extends Void> send(Packet packet);
-
-    /**
-     * Disconnect client
-     *
-     */
-    void disconnect();
-
-    /**
-     * Send event
-     *
-     * @param name - event name
-     * @param data - event data
-     */
-    NetworkCallback<? extends Void> sendEvent(String name, Object ... data);
+public interface NetworkCallback<V> extends Future<V> {
+    /* todo: replace with <? extends Future<? super V>> */
+    void addCallback(NetworkCallbackListener<Future<? super V>> callback);
 }

--- a/src/main/java/com/corundumstudio/socketio/NetworkCallbackListener.java
+++ b/src/main/java/com/corundumstudio/socketio/NetworkCallbackListener.java
@@ -15,34 +15,12 @@
  */
 package com.corundumstudio.socketio;
 
-import com.corundumstudio.socketio.protocol.Packet;
+import java.util.concurrent.Future;
+import java.util.EventListener;
 
 /**
- * Available client operations
- *
+ * Listener for {@link NetworkCallback}.
  */
-public interface ClientOperations {
-
-    /**
-     * Send custom packet.
-     * But {@link ClientOperations#sendEvent} method
-     * usage is enough for most cases.
-     *
-     * @param packet - packet to send
-     */
-    NetworkCallback<? extends Void> send(Packet packet);
-
-    /**
-     * Disconnect client
-     *
-     */
-    void disconnect();
-
-    /**
-     * Send event
-     *
-     * @param name - event name
-     * @param data - event data
-     */
-    NetworkCallback<? extends Void> sendEvent(String name, Object ... data);
+public interface NetworkCallbackListener<F extends Future<?>> extends EventListener {
+    void operationComplete(F var1) throws Exception;
 }

--- a/src/main/java/com/corundumstudio/socketio/NetworkCallbacks.java
+++ b/src/main/java/com/corundumstudio/socketio/NetworkCallbacks.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2012 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.corundumstudio.socketio;
+
+import com.corundumstudio.socketio.concurrent.FailedFuture;
+import com.corundumstudio.socketio.concurrent.SucceededFuture;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+
+/**
+ * Object instances of {@link NetworkCallback}
+ */
+public class NetworkCallbacks {
+    private static Throwable CHANNEL_CLOSED_ERROR = new IllegalStateException("channel is closed");
+
+    public static <T> NetworkCallback<T> channelClosed()  {
+        return new FailedFuture<T>(ImmediateEventExecutor.INSTANCE, CHANNEL_CLOSED_ERROR);
+    }
+
+    public static <T> NetworkCallback<T> success(T value)  {
+        return new SucceededFuture<T>(ImmediateEventExecutor.INSTANCE, value);
+    }
+
+    public static <E extends Throwable> NetworkCallback<E> failure(E throwable)  {
+        return new FailedFuture<E>(ImmediateEventExecutor.INSTANCE, throwable);
+    }
+}

--- a/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
@@ -109,4 +109,9 @@ public interface SocketIOClient extends ClientOperations, Store {
      */
     Set<String> getAllRooms();
 
+    /**
+     * Check is network buffer is empty and client is ready to read a data.
+     * @return true in case channel is ready to consume a bit of data.
+     */
+    boolean isWritable();
 }

--- a/src/main/java/com/corundumstudio/socketio/concurrent/CompleteFuture.java
+++ b/src/main/java/com/corundumstudio/socketio/concurrent/CompleteFuture.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2012 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.corundumstudio.socketio.concurrent;
+
+import com.corundumstudio.socketio.NetworkCallback;
+import com.corundumstudio.socketio.NetworkCallbackListener;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.GenericFutureListener;
+
+import java.util.concurrent.Future;
+
+/**
+ * Simple promise which already has a result.
+ */
+public abstract class CompleteFuture<V> extends io.netty.util.concurrent.CompleteFuture <V> implements NetworkCallback<V> {
+
+    protected CompleteFuture(EventExecutor executor) {
+        super(executor);
+    }
+
+    @Override
+    public void addCallback(final NetworkCallbackListener<Future<? super V>> callback) {
+        super.addListener(new GenericFutureListener<io.netty.util.concurrent.Future<? super V>>() {
+            @Override
+            public void operationComplete(io.netty.util.concurrent.Future<? super V> future) throws Exception {
+                callback.operationComplete(future);
+            }
+        });
+    }
+}

--- a/src/main/java/com/corundumstudio/socketio/concurrent/DefaultNetworkPromise.java
+++ b/src/main/java/com/corundumstudio/socketio/concurrent/DefaultNetworkPromise.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2012 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.corundumstudio.socketio.concurrent;
+
+import com.corundumstudio.socketio.NetworkCallback;
+import com.corundumstudio.socketio.NetworkCallbackListener;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.GenericFutureListener;
+
+import java.util.concurrent.Future;
+
+/**
+ * Simple network callback.
+ */
+public class DefaultNetworkPromise<V> extends DefaultPromise<V> implements NetworkCallback<V> {
+
+    public DefaultNetworkPromise(EventExecutor executor) {
+        super(executor);
+    }
+
+    @Override
+    public void addCallback(final NetworkCallbackListener<Future<? super V>> callback) {
+        super.addListener(new GenericFutureListener<io.netty.util.concurrent.Future<? super V>>() {
+            @Override
+            public void operationComplete(io.netty.util.concurrent.Future<? super V> future) throws Exception {
+                callback.operationComplete(future);
+            }
+        });
+    }
+}

--- a/src/main/java/com/corundumstudio/socketio/concurrent/FailedFuture.java
+++ b/src/main/java/com/corundumstudio/socketio/concurrent/FailedFuture.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2012 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.corundumstudio.socketio.concurrent;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.internal.PlatformDependent;
+
+public final class FailedFuture<V> extends CompleteFuture<V> {
+    private final Throwable cause;
+
+    public FailedFuture(EventExecutor executor, Throwable cause) {
+        super(executor);
+        if (cause == null) {
+            throw new NullPointerException("cause");
+        } else {
+            this.cause = cause;
+        }
+    }
+
+    public Throwable cause() {
+        return this.cause;
+    }
+
+    public boolean isSuccess() {
+        return false;
+    }
+
+    public Future<V> sync() {
+        PlatformDependent.throwException(this.cause);
+        return this;
+    }
+
+    public Future<V> syncUninterruptibly() {
+        PlatformDependent.throwException(this.cause);
+        return this;
+    }
+
+    public V getNow() {
+        return null;
+    }
+}

--- a/src/main/java/com/corundumstudio/socketio/concurrent/SucceededFuture.java
+++ b/src/main/java/com/corundumstudio/socketio/concurrent/SucceededFuture.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2012 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.corundumstudio.socketio.concurrent;
+
+import io.netty.util.concurrent.EventExecutor;
+
+public final class SucceededFuture<V> extends CompleteFuture<V> {
+    private final V result;
+
+    public SucceededFuture(EventExecutor executor, V result) {
+        super(executor);
+        this.result = result;
+    }
+
+    public Throwable cause() {
+        return null;
+    }
+
+    public boolean isSuccess() {
+        return true;
+    }
+
+    public V getNow() {
+        return this.result;
+    }
+}

--- a/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
@@ -15,19 +15,6 @@
  */
 package com.corundumstudio.socketio.handler;
 
-import java.net.SocketAddress;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Queue;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.corundumstudio.socketio.Configuration;
 import com.corundumstudio.socketio.DisconnectableHub;
 import com.corundumstudio.socketio.HandshakeData;
@@ -43,13 +30,21 @@ import com.corundumstudio.socketio.scheduler.SchedulerKey.Type;
 import com.corundumstudio.socketio.store.Store;
 import com.corundumstudio.socketio.store.StoreFactory;
 import com.corundumstudio.socketio.transport.NamespaceClient;
-
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.PlatformDependent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.SocketAddress;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ClientHead {
 
@@ -76,8 +71,8 @@ public class ClientHead {
     private volatile Transport currentTransport;
 
     public ClientHead(UUID sessionId, AckManager ackManager, DisconnectableHub disconnectable,
-            StoreFactory storeFactory, HandshakeData handshakeData, ClientsBox clientsBox, Transport transport, CancelableScheduler disconnectScheduler,
-            Configuration configuration) {
+                      StoreFactory storeFactory, HandshakeData handshakeData, ClientsBox clientsBox, Transport transport, CancelableScheduler disconnectScheduler,
+                      Configuration configuration) {
         this.sessionId = sessionId;
         this.ackManager = ackManager;
         this.disconnectableHub = disconnectable;
@@ -130,6 +125,22 @@ public class ClientHead {
                 }
             }
         }, configuration.getPingTimeout() + configuration.getPingInterval(), TimeUnit.MILLISECONDS);
+    }
+
+    public boolean isWritable() {
+        TransportState state = channels.get(getCurrentTransport());
+        Channel channel = state.getChannel();
+        return channel != null && channel.isWritable();
+    }
+
+    public EventLoop eventLoop() {
+        TransportState state = channels.get(getCurrentTransport());
+        Channel channel = state.getChannel();
+        if (channel != null) {
+            return channel.eventLoop();
+        } else {
+            return null;
+        }
     }
 
     public ChannelFuture send(Packet packet, Transport transport) {
@@ -260,6 +271,7 @@ public class ClientHead {
     public void setLastBinaryPacket(Packet lastBinaryPacket) {
         this.lastBinaryPacket = lastBinaryPacket;
     }
+
     public Packet getLastBinaryPacket() {
         return lastBinaryPacket;
     }


### PR DESCRIPTION
I've tried to find a way to use netty callbacks and checks if netty buffer is ready to consume more information. Please review this small patch to #172 

Example, how it could be used (where `client: SocketIOClient`, and `ctx` is context of netty `ctx: ChannelHandlerContext`)

```
if (client.isWritable) client.sendEvent("server_response", msg)
else {
  ctx.channel().config().setAutoRead(false)
  client
    .sendEvent("server_response", msg)
    .addCallback(r => if (r.isDone) ctx.channel().config().setAutoRead(true))
}
```

In deep it uses netty futures and promises but outside only pure `java.util.concurrent.Future` and some new interfaces in the package `com.corundumstudio.socketio.concurrent`  in order to make it possible to use another implementation.