### PR TITLE
Fix for issue #481

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/SocketIOServer.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOServer.java
@@ -171,8 +171,8 @@ public class SocketIOServer implements ClientListeners {
             bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(config.getTcpReceiveBufferSize()));
         }
         bootstrap.childOption(ChannelOption.SO_KEEPALIVE, config.isTcpKeepAlive());
+        bootstrap.childOption(ChannelOption.SO_LINGER, config.getSoLinger());
 
-        bootstrap.option(ChannelOption.SO_LINGER, config.getSoLinger());
         bootstrap.option(ChannelOption.SO_REUSEADDR, config.isReuseAddress());
         bootstrap.option(ChannelOption.SO_BACKLOG, config.getAcceptBackLog());
     }


### PR DESCRIPTION
The SO_LINGER option is a child channel option, not a server option - changed the bootstrapping code to do correctly. In earlier versions of Netty this was silently ignored, but in newer version (4.1.15.Final as well) a warning is shown, and also the option is ignored.

Sorry for the messed up commits, I got confused a little with the commit messages  :)