### PR TITLE
Fix NumberFormatException when b64 is bool value.

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/transport/PollingTransport.java
+++ b/src/main/java/com/corundumstudio/socketio/transport/PollingTransport.java
@@ -88,7 +88,13 @@ public class PollingTransport extends ChannelInboundHandlerAdapter {
                     ctx.channel().attr(EncoderHandler.JSONP_INDEX).set(index);
                 }
                 if (b64 != null && b64.get(0) != null) {
-                    Integer enable = Integer.valueOf(b64.get(0));
+                    String flag = b64.get(0);
+                    if ("true".equals(flag)) {
+                        flag = "1";
+                    } else if ("false".equals(flag)) {
+                        flag = "0";
+                    }
+                    Integer enable = Integer.valueOf(flag);
                     ctx.channel().attr(EncoderHandler.B64).set(enable == 1);
                 }
 


### PR DESCRIPTION
Cause:
- when the b64 is set as bool value like "http://<hostaddress>/socket.io/1/?EIO=2&transport=polling&b64=true",
Exception [java.lang.NumberFormatException: For input string: "true"] will throw.
Because it try to parse a string "true" to Integer.

Fix:
- take true as 1 and take false as 0