### PR TITLE
Some utf8 characters may become "???', if polling is used

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
@@ -135,9 +135,6 @@ public class PacketDecoder {
             int len = utf8scanner.getActualLength(buffer, lenHeader);
 
             ByteBuf frame = buffer.slice(buffer.readerIndex() + 1, len);
-            if (lenHeader != len) {
-                frame = Unpooled.wrappedBuffer(frame.toString(CharsetUtil.UTF_8).getBytes(CharsetUtil.ISO_8859_1));
-            }
             // skip this frame
             buffer.readerIndex(buffer.readerIndex() + 1 + len);
             return decode(client, frame);

--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
@@ -64,13 +64,6 @@ public class PacketDecoder {
             packet = packet.substring(2);
         }
 
-	/**
-	 * this line will convert some utf-8 characters to "?"
-	 *
-	 * @see https://github.com/mrniko/netty-socketio/issues/515
-	 */
-        // packet = new String(packet.getBytes(CharsetUtil.ISO_8859_1), CharsetUtil.UTF_8);
-
         return Unpooled.wrappedBuffer(packet.getBytes(CharsetUtil.UTF_8));
     }
 

--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
@@ -63,7 +63,13 @@ public class PacketDecoder {
             // skip "d="
             packet = packet.substring(2);
         }
-        packet = new String(packet.getBytes(CharsetUtil.ISO_8859_1), CharsetUtil.UTF_8);
+
+	/**
+	 * this line will convert some utf-8 characters to "?"
+	 *
+	 * @see https://github.com/mrniko/netty-socketio/issues/515
+	 */
+        // packet = new String(packet.getBytes(CharsetUtil.ISO_8859_1), CharsetUtil.UTF_8);
 
         return Unpooled.wrappedBuffer(packet.getBytes(CharsetUtil.UTF_8));
     }


### PR DESCRIPTION
Hi,
I found that there is something confusing at com.corundumstudio.socketio.protocol.PacketDecoder, it may convert some utf8 characters  to "???"
I create an [issue](https://github.com/mrniko/netty-socketio/issues/515) 
```
// TODO optimize
public ByteBuf preprocessJson(Integer jsonIndex, ByteBuf content) throws IOException {
    String packet = URLDecoder.decode(content.toString(CharsetUtil.UTF_8), CharsetUtil.UTF_8.name());

    if (jsonIndex != null) {
        /**
        * double escaping is required for escaped new lines because unescaping of new lines can be done safely on server-side
        * (c) socket.io.js
        *
        * @see https://github.com/Automattic/socket.io-client/blob/1.3.3/socket.io.js#L2682
        */
        packet = packet.replace("\\\\n", "\\n");

        // skip "d="
        packet = packet.substring(2);
    }
    packet = new String(packet.getBytes(CharsetUtil.ISO_8859_1), CharsetUtil.UTF_8);

    return Unpooled.wrappedBuffer(packet.getBytes(CharsetUtil.UTF_8));
}
```
this line is very confusing:
`packet = new String(packet.getBytes(CharsetUtil.ISO_8859_1), CharsetUtil.UTF_8);`

some other detail I record in the [issue515](https://github.com/mrniko/netty-socketio/issues/515)