### PR TITLE
add PingListener

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/SocketIOServer.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOServer.java
@@ -15,6 +15,7 @@
  */
 package com.corundumstudio.socketio;
 
+import com.corundumstudio.socketio.listener.*;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -34,11 +35,6 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.corundumstudio.socketio.listener.ClientListeners;
-import com.corundumstudio.socketio.listener.ConnectListener;
-import com.corundumstudio.socketio.listener.DataListener;
-import com.corundumstudio.socketio.listener.DisconnectListener;
-import com.corundumstudio.socketio.listener.MultiTypeEventListener;
 import com.corundumstudio.socketio.namespace.Namespace;
 import com.corundumstudio.socketio.namespace.NamespacesHub;
 
@@ -244,6 +240,11 @@ public class SocketIOServer implements ClientListeners {
     @Override
     public void addConnectListener(ConnectListener listener) {
         mainNamespace.addConnectListener(listener);
+    }
+
+    @Override
+    public void addPingListeners(PingListener pingListener) {
+        mainNamespace.addPingListeners(pingListener);
     }
 
     @Override

--- a/src/main/java/com/corundumstudio/socketio/handler/PacketListener.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/PacketListener.java
@@ -62,6 +62,8 @@ public class PacketListener {
             } else {
                 client.getBaseClient().schedulePingTimeout();
             }
+            Namespace namespace = namespacesHub.get(packet.getNsp());
+            namespace.onPing(client);
             break;
         }
 

--- a/src/main/java/com/corundumstudio/socketio/listener/ClientListeners.java
+++ b/src/main/java/com/corundumstudio/socketio/listener/ClientListeners.java
@@ -25,6 +25,8 @@ public interface ClientListeners {
 
     void addConnectListener(ConnectListener listener);
 
+    void addPingListeners(PingListener pingListener);
+
     void addListeners(Object listeners);
 
     void addListeners(Object listeners, Class<?> listenersClass);

--- a/src/main/java/com/corundumstudio/socketio/listener/DefaultExceptionListener.java
+++ b/src/main/java/com/corundumstudio/socketio/listener/DefaultExceptionListener.java
@@ -44,6 +44,11 @@ public class DefaultExceptionListener extends ExceptionListenerAdapter {
     }
 
     @Override
+    public void onPingException(Exception e, SocketIOClient client) {
+        log.error(e.getMessage(), e);
+    }
+
+    @Override
     public boolean exceptionCaught(ChannelHandlerContext ctx, Throwable e) throws Exception {
         log.error(e.getMessage(), e);
         return true;

--- a/src/main/java/com/corundumstudio/socketio/listener/PingListener.java
+++ b/src/main/java/com/corundumstudio/socketio/listener/PingListener.java
@@ -15,22 +15,10 @@
  */
 package com.corundumstudio.socketio.listener;
 
-import io.netty.channel.ChannelHandlerContext;
-
-import java.util.List;
-
 import com.corundumstudio.socketio.SocketIOClient;
 
-public interface ExceptionListener {
+public interface PingListener {
 
-    void onEventException(Exception e, List<Object> args, SocketIOClient client);
-
-    void onDisconnectException(Exception e, SocketIOClient client);
-
-    void onConnectException(Exception e, SocketIOClient client);
-
-    void onPingException(Exception e, SocketIOClient client);
-
-    boolean exceptionCaught(ChannelHandlerContext ctx, Throwable e) throws Exception;
+    void onPing(SocketIOClient client);
 
 }

--- a/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
+++ b/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
@@ -34,11 +34,7 @@ import com.corundumstudio.socketio.MultiTypeArgs;
 import com.corundumstudio.socketio.SocketIOClient;
 import com.corundumstudio.socketio.SocketIONamespace;
 import com.corundumstudio.socketio.annotation.ScannerEngine;
-import com.corundumstudio.socketio.listener.ConnectListener;
-import com.corundumstudio.socketio.listener.DataListener;
-import com.corundumstudio.socketio.listener.DisconnectListener;
-import com.corundumstudio.socketio.listener.ExceptionListener;
-import com.corundumstudio.socketio.listener.MultiTypeEventListener;
+import com.corundumstudio.socketio.listener.*;
 import com.corundumstudio.socketio.protocol.JsonSupport;
 import com.corundumstudio.socketio.protocol.Packet;
 import com.corundumstudio.socketio.store.StoreFactory;
@@ -62,6 +58,7 @@ public class Namespace implements SocketIONamespace {
     private final ConcurrentMap<String, EventEntry<?>> eventListeners = PlatformDependent.newConcurrentHashMap();
     private final Queue<ConnectListener> connectListeners = new ConcurrentLinkedQueue<ConnectListener>();
     private final Queue<DisconnectListener> disconnectListeners = new ConcurrentLinkedQueue<DisconnectListener>();
+    private final Queue<PingListener> pingListeners = new ConcurrentLinkedQueue<PingListener>();
 
     private final Map<UUID, SocketIOClient> allClients = PlatformDependent.newConcurrentHashMap();
     private final ConcurrentMap<String, Set<UUID>> roomClients = PlatformDependent.newConcurrentHashMap();
@@ -212,6 +209,21 @@ public class Namespace implements SocketIONamespace {
             }
         } catch (Exception e) {
             exceptionListener.onConnectException(e, client);
+        }
+    }
+
+    @Override
+    public void addPingListeners(PingListener pingListener) {
+        pingListeners.add(pingListener);
+    }
+
+    public void onPing(SocketIOClient client) {
+        try {
+            for (PingListener listener : pingListeners) {
+                listener.onPing(client);
+            }
+        } catch (Exception e) {
+            exceptionListener.onPingException(e, client);
         }
     }
 


### PR DESCRIPTION
Add PingListener to handle ping event. Sometimes it is important to know when clients send ping data to server. In distributed environments, to manage the information of online clients, we can put it into Redis when servers receive the ping data from clients, and set or update a expiry time for each client. In this way, managing the data of online clients becomes easy.