### PR TITLE
add ThreadFactory for HashedWheelTimer

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/scheduler/HashedWheelScheduler.java
+++ b/src/main/java/com/corundumstudio/socketio/scheduler/HashedWheelScheduler.java
@@ -15,19 +15,28 @@
  */
 package com.corundumstudio.socketio.scheduler;
 
+import java.util.Map;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import io.netty.util.internal.PlatformDependent;
 
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 public class HashedWheelScheduler implements CancelableScheduler {
 
     private final Map<SchedulerKey, Timeout> scheduledFutures = PlatformDependent.newConcurrentHashMap();
-    private final HashedWheelTimer executorService = new HashedWheelTimer();
+    private final HashedWheelTimer executorService;
+    
+    public HashedWheelScheduler() {
+        executorService = new HashedWheelTimer();
+    }
+    
+    public HashedWheelScheduler(ThreadFactory threadFactory) {
+        executorService = new HashedWheelTimer(threadFactory);
+    }
 
     private volatile ChannelHandlerContext ctx;
 

--- a/src/main/java/com/corundumstudio/socketio/scheduler/HashedWheelTimeoutScheduler.java
+++ b/src/main/java/com/corundumstudio/socketio/scheduler/HashedWheelTimeoutScheduler.java
@@ -31,14 +31,23 @@ import io.netty.util.TimerTask;
 import io.netty.util.internal.PlatformDependent;
 
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 public class HashedWheelTimeoutScheduler implements CancelableScheduler {
 
     private final ConcurrentMap<SchedulerKey, Timeout> scheduledFutures = PlatformDependent.newConcurrentHashMap();
-    private final HashedWheelTimer executorService = new HashedWheelTimer();
+    private final HashedWheelTimer executorService;
 
     private volatile ChannelHandlerContext ctx;
+    
+    public HashedWheelTimeoutScheduler() {
+        executorService = new HashedWheelTimer();
+    }
+    
+    public HashedWheelTimeoutScheduler(ThreadFactory threadFactory) {
+        executorService = new HashedWheelTimer(threadFactory);
+    }
 
     @Override
     public void update(ChannelHandlerContext ctx) {


### PR DESCRIPTION
Sometimes  needs to make HashedWheelTimer working on daemon mode  to shutdown fastly. Using ThreadFactory also can rename the threads created in HashedWheelTimer .