### PR TITLE
#503 fix the "fin_close" problem

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/transport/WebSocketTransport.java
+++ b/src/main/java/com/corundumstudio/socketio/transport/WebSocketTransport.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.corundumstudio.socketio.protocol.Packet;
+import com.corundumstudio.socketio.protocol.PacketType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,12 +140,17 @@ public class WebSocketTransport extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        ClientHead client = clientsBox.get(ctx.channel());
+        final  Channel channel = ctx.channel();
+        ClientHead client = clientsBox.get(channel);
+        Packet packet = new Packet(PacketType.MESSAGE);
         if (client != null && client.isTransportChannel(ctx.channel(), Transport.WEBSOCKET)) {
             log.debug("channel inactive {}", client.getSessionId());
             client.onChannelDisconnect();
         }
         super.channelInactive(ctx);
+        client.send(packet);
+        channel.close();
+        ctx.close();
     }
 
     private void handshake(ChannelHandlerContext ctx, final UUID sessionId, String path, FullHttpRequest req) {


### PR DESCRIPTION
There are  many close_wait so that the socketserver can not respone any requests.

And then I check the code  and I found that the function (in com.corundumstudio.socketio.transport.WebSocketTransport) 
`@Override
    public void channelInactive(ChannelHandlerContext ctx) throws Exception {

        ClientHead client = clientsBox.get(ctx.channel());

        if (client != null && client.isTransportChannel(ctx.channel(), Transport.WEBSOCKET)) {

            log.debug("channel inactive {}", client.getSessionId());

            client.onChannelDisconnect();

        }

        super.channelInactive(ctx);

    }`

just relase the client socket.  It would cause the client go into fin_wait ,and server go into close_wait.
If client found the connect can't work,it would reconnet,so There are  many close_wait so that the socketserver can not respone any requests!

I try to fix this problem like that 
`@Override
    public void channelInactive(ChannelHandlerContext ctx) throws Exception {

        ClientHead client = clientsBox.get(ctx.channel());

        Packet packet = new Packet(PacketType.MESSAGE);

        packet.setData("channel will  be closed");

        if (client != null && client.isTransportChannel(ctx.channel(), Transport.WEBSOCKET)) {

            log.debug("channel inactive {}", client.getSessionId());

            client.onChannelDisconnect();

        }

        super.channelInactive(ctx);

        client.send(packet);

        channel.close();

        ctx.close();

    }`
It works!  If the client go into fin_wait( Maybe some problem on the network ),the server will go into fin_wait at once,so the connect will be relase! And then the new connection will be built immediately.

