### PR TITLE
fix for underlying connection not closing on ping timeout

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
@@ -125,7 +125,7 @@ public class ClientHead {
             public void run() {
                 ClientHead client = clientsBox.get(sessionId);
                 if (client != null) {
-                    client.onChannelDisconnect();
+                    client.disconnect();
                     log.debug("{} removed due to ping timeout", sessionId);
                 }
             }

--- a/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
@@ -205,7 +205,9 @@ public class ClientHead {
 
     public void disconnect() {
         ChannelFuture future = send(new Packet(PacketType.DISCONNECT));
-        future.addListener(ChannelFutureListener.CLOSE);
+		if(future != null) {
+			future.addListener(ChannelFutureListener.CLOSE);
+		}
 
         onChannelDisconnect();
     }


### PR DESCRIPTION
on ping timeout, `client.disconnect` needs to be called instead of `client.onChannelDisconnect`