### PR TITLE
fix NPE  &  mem leak

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/transport/WebSocketTransport.java
+++ b/src/main/java/com/corundumstudio/socketio/transport/WebSocketTransport.java
@@ -142,7 +142,7 @@ public class WebSocketTransport extends ChannelInboundHandlerAdapter {
         final  Channel channel = ctx.channel();
         ClientHead client = clientsBox.get(channel);
         Packet packet = new Packet(PacketType.MESSAGE);
-        packet.setSubType(PacketType.MESSAGE);
+        packet.setSubType(PacketType.DISCONNECT);
         if (client != null && client.isTransportChannel(ctx.channel(), Transport.WEBSOCKET)) {
             log.debug("channel inactive {}", client.getSessionId());
             client.onChannelDisconnect();


### PR DESCRIPTION
#596
reason:
WebSocketTransport line 144 : Packet packet = new Packet(PacketType.MESSAGE); //subType =null
PacketEncoder line 288: byte subType = toChar(packet.getSubType().getValue()); //NullPointerException

fix
WebSocketTransport
Packet packet = new Packet(PacketType.MESSAGE);
packet.setSubType(PacketType.DISCONNECT);