### PR TITLE
fix invalid namespace

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
@@ -279,7 +279,7 @@ public class PacketDecoder {
         if (packet.getType() == PacketType.MESSAGE) {
             if (packet.getSubType() == PacketType.CONNECT
                     || packet.getSubType() == PacketType.DISCONNECT) {
-                packet.setNsp(readString(frame));
+                packet.setNsp(readNamespace(frame));
             }
 
             if (packet.hasAttachments() && !packet.isAttachmentsLoaded()) {
@@ -308,6 +308,23 @@ public class PacketDecoder {
                 packet.setData(event.getArgs());
             }
         }
+    }
+    
+    private String readNamespace(ByteBuf frame){
+        /**
+         * namespace post request with url queryString, like
+         *  /message?a=1,
+         *  /message,
+         */
+        int endIndex = frame.bytesBefore((byte)'?');
+        if(endIndex > 0){
+            return readString(frame,endIndex);
+        }
+        endIndex = frame.bytesBefore((byte)',');
+        if(endIndex > 0){
+            return readString(frame,endIndex);
+        }
+        return readString(frame);
     }
 
 }


### PR DESCRIPTION
socketio.js 2.0 + node socktio.js  -> work well
socketio.js 2.0 + netty-socketio-1.7.16 -> invalid namespace

**reason:**
namespace request payload contains url query string info, like 
`8:40/chat,`
`49:40/chatroom?uid=ba7822bee25940ada9d2a987670afc5d,`

it does'n match `/chat` or `/chatroom` in namespacehub

**fix:** 
before `packet.setNsp`, sub the query string