### PR TITLE
Add 307 redirect to AuthorizationListener

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/AuthorizationListener.java
+++ b/src/main/java/com/corundumstudio/socketio/AuthorizationListener.java
@@ -18,10 +18,17 @@ package com.corundumstudio.socketio;
 public interface AuthorizationListener {
 
     /**
-     * Checks is client with handshake data is authorized
+     * Checks if client with handshake data is redirected (307)
+     *
+     * @return - the <b>URL</b> if client is redirected or <b>null</b> otherwise
+     */
+    String isRedirected(HandshakeData data);
+
+    /**
+     * Checks if client with handshake data is authorized
      *
      * @param data - handshake data
-     * @return - <b>true</b> if client is authorized of <b>false</b> otherwise
+     * @return - <b>true</b> if client is authorized or <b>false</b> otherwise
      */
     boolean isAuthorized(HandshakeData data);
 

--- a/src/main/java/com/corundumstudio/socketio/handler/SuccessAuthorizationListener.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/SuccessAuthorizationListener.java
@@ -21,6 +21,11 @@ import com.corundumstudio.socketio.HandshakeData;
 public class SuccessAuthorizationListener implements AuthorizationListener {
 
     @Override
+    public String isRedirected(HandshakeData data) {
+        return null;
+    }
+
+    @Override
     public boolean isAuthorized(HandshakeData data) {
         return true;
     }


### PR DESCRIPTION
Use case:

For building a server cluster, we wanted to 307 redirect to another machine before authentication occurs. I added an `@Override isRedirected()` to AuthorizationListener for this. I tried to make the change without breaking compatibility.

If it interests you, feel free to merge. If there's a better way to achieve this, please let me know.

I based the change on 1.7.13 because it's the latest stable version.