### PR TITLE
Make "Event" class public

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/protocol/Event.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/Event.java
@@ -17,7 +17,7 @@ package com.corundumstudio.socketio.protocol;
 
 import java.util.List;
 
-class Event {
+public class Event {
 
     private String name;
     private List<Object> args;


### PR DESCRIPTION
In order to create custom serialization code (using `JsonSupport`) I need to be able to create `Event` instances