### PR TITLE
Avoid BindException after restart

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/SocketConfig.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketConfig.java
@@ -33,7 +33,7 @@ public class SocketConfig {
 
     private int soLinger = -1;
 
-    private boolean reuseAddress = false;
+    private boolean reuseAddress = true;
 
     private int acceptBackLog = 1024;
 


### PR DESCRIPTION
Sometimes server start failed after restart, like:
#687 
#698 
Some developers don't know how to solve this problem, so I think this is a good idea to set the default value of SocketConfig.reuseAddress to true. It can avoid the BindException.