### PR TITLE
Add namespace support for SpringAnnotationScanner.

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/annotation/Namespace.java
+++ b/src/main/java/com/corundumstudio/socketio/annotation/Namespace.java
@@ -1,0 +1,17 @@
+package com.corundumstudio.socketio.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that defines <b>Namespace</b> for event handler class.
+ *
+ * Need to use with {@link SpringAnnotationScanner}.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Namespace {
+    String value();
+}


### PR DESCRIPTION
Added `@Namespace` annotation for adding listeners to non-default namespaces when configuring with `SpringAnnotationScanner`.