### PR TITLE
Get the number of clinets in a room in a cluster environment

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
@@ -109,4 +109,13 @@ public interface SocketIOClient extends ClientOperations, Store {
      */
     Set<String> getAllRooms();
 
+    /**
+     * Get current room Size (contain in cluster)
+     *
+     * @param room - name of room
+     *
+     * @return int
+     */
+    int getCurrentRoomSize(String room);
+
 }

--- a/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
+++ b/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
@@ -368,6 +368,11 @@ public class Namespace implements SocketIONamespace {
         return result;
     }
 
+    public int getRoomClientsInCluster(String room) {
+        Set<UUID> sessionIds = roomClients.get(room);
+        return sessionIds == null ? 0 : sessionIds.size();
+    }
+
     @Override
     public Collection<SocketIOClient> getAllClients() {
         return Collections.unmodifiableCollection(allClients.values());

--- a/src/main/java/com/corundumstudio/socketio/transport/NamespaceClient.java
+++ b/src/main/java/com/corundumstudio/socketio/transport/NamespaceClient.java
@@ -203,6 +203,11 @@ public class NamespaceClient implements SocketIOClient {
     }
 
     @Override
+    public int getCurrentRoomSize(String room) {
+        return namespace.getRoomClientsInCluster(room);
+    }
+
+    @Override
     public HandshakeData getHandshakeData() {
         return baseClient.getHandshakeData();
     }


### PR DESCRIPTION
```
public Iterable<SocketIOClient> getRoomClients(String room) {
       //This value is the total number of clients in the current room in the cluster
        Set<UUID> sessionIds = roomClients.get(room);

        if (sessionIds == null) {
            return Collections.emptyList();
        }
        //At this time, the clients that are not in the current server in the current room are filtered out
        List<SocketIOClient> result = new ArrayList<SocketIOClient>();
        for (UUID sessionId : sessionIds) {
            SocketIOClient client = allClients.get(sessionId);
            if(client != null) {
                result.add(client);
            }
        }
       //So the number of clients in the current room I get is only for the current server, not for the entire cluster
        return result;
    }

```