### PR TITLE
Fixed bug on illegal transport parameter

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/Transport.java
+++ b/src/main/java/com/corundumstudio/socketio/Transport.java
@@ -32,14 +32,4 @@ public enum Transport {
     public String getValue() {
         return value;
     }
-
-    public static Transport byName(String value) {
-        for (Transport t : Transport.values()) {
-            if (t.getValue().equals(value)) {
-                return t;
-            }
-        }
-        throw new IllegalArgumentException("Can't find " + value + " transport");
-    }
-
 }


### PR DESCRIPTION
Hello! 
I have tried to fix small bug on connect with missing or invalid transport parameter.
This [Socket.io docs](https://socket.io/docs/v3/troubleshooting-connection-issues/) describe expected behavior.
> In case of an HTTP 400 response, the response payload will be one of the following:
> `{"code":0,"message":"Transport unknown"}`
> The transport query parameter is missing or invalid.
> To reproduce: curl "<url>/socket.io/" or curl "<url>/socket.io/?transport=udp"

### Сurrent behavior (tested on [Demo-Project](https://github.com/mrniko/netty-socketio-demo) )
**On curl with wrong transport:**
`
curl http://localhost:9092/socket.io/?transport=udp
//keeping connection
`
**on log:**
`
[nioEventLoopGroup-3-1] WARN io.netty.channel.DefaultChannelPipeline - An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.lang.IllegalArgumentException: Can't find http transport
	at com.corundumstudio.socketio.Transport.byName(Transport.java:42)
	at com.corundumstudio.socketio.handler.AuthorizeHandler.authorize(AuthorizeHandler.java:157)
	at com.corundumstudio.socketio.handler.AuthorizeHandler.channelRead(AuthorizeHandler.java:108)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:108)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:182)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:846)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:130)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:511)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysPlain(NioEventLoop.java:430)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:384)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:354)
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116)
	at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
	at java.base/java.lang.Thread.run(Thread.java:831)
`