### PR TITLE
Expose client auth option

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/Configuration.java
+++ b/src/main/java/com/corundumstudio/socketio/Configuration.java
@@ -88,6 +88,8 @@ public class Configuration {
 
     private boolean randomSession = false;
 
+    private boolean needClientAuth = false;
+
     public Configuration() {
     }
 
@@ -154,6 +156,7 @@ public class Configuration {
         setHttpCompression(conf.isHttpCompression());
         setWebsocketCompression(conf.isWebsocketCompression());
         setRandomSession(conf.randomSession);
+        setNeedClientAuth(conf.isNeedClientAuth());
     }
 
     public JsonSupport getJsonSupport() {
@@ -583,5 +586,20 @@ public class Configuration {
 
     public void setRandomSession(boolean randomSession) {
         this.randomSession = randomSession;
+    }
+
+    /**
+     * Enable/disable client authentication.
+     * Has no effect unless a trust store has been provided.
+     *
+     * Default is <code>false</code>
+     *
+     * @param needClientAuth - <code>true</code> to use client authentication
+     */
+    public void setNeedClientAuth(boolean needClientAuth) {
+        this.needClientAuth = needClientAuth;
+    }
+    public boolean isNeedClientAuth() {
+        return needClientAuth;
     }
 }

--- a/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
@@ -155,6 +155,9 @@ public class SocketIOChannelInitializer extends ChannelInitializer<Channel> impl
         if (sslContext != null) {
             SSLEngine engine = sslContext.createSSLEngine();
             engine.setUseClientMode(false);
+            if (configuration.isNeedClientAuth() &&(configuration.getTrustStore() != null)) {
+                engine.setNeedClientAuth(true);
+            }
             pipeline.addLast(SSL_HANDLER, new SslHandler(engine));
         }
     }


### PR DESCRIPTION
This fixes issue #503, by exposing a client auth option for TLS connections.  When configured, client connection attempts are rejected unless they present a certificate allowed by the trust store.  If no trust store is configured, the setting has no effect.