### PR TITLE
Added support for bulk join and leave

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
@@ -96,11 +96,25 @@ public interface SocketIOClient extends ClientOperations, Store {
     void joinRoom(String room);
 
     /**
-     * Join client to room
+     * Join client to rooms
+     *
+     * @param rooms - names of rooms
+     */
+    void joinRooms(Set<String> rooms);
+
+    /**
+     * Leave client from room
      *
      * @param room - name of room
      */
     void leaveRoom(String room);
+
+    /**
+     * Leave client from rooms
+     *
+     * @param rooms - names of rooms
+     */
+    void leaveRooms(Set<String> rooms);
 
     /**
      * Get all rooms a client is joined in.

--- a/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
+++ b/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
@@ -38,6 +38,7 @@ import com.corundumstudio.socketio.listener.*;
 import com.corundumstudio.socketio.protocol.JsonSupport;
 import com.corundumstudio.socketio.protocol.Packet;
 import com.corundumstudio.socketio.store.StoreFactory;
+import com.corundumstudio.socketio.store.pubsub.BulkJoinLeaveMessage;
 import com.corundumstudio.socketio.store.pubsub.JoinLeaveMessage;
 import com.corundumstudio.socketio.store.pubsub.PubSubType;
 import com.corundumstudio.socketio.transport.NamespaceClient;
@@ -287,6 +288,13 @@ public class Namespace implements SocketIONamespace {
         storeFactory.pubSubStore().publish(PubSubType.JOIN, new JoinLeaveMessage(sessionId, room, getName()));
     }
 
+    public void joinRooms(Set<String> rooms, final UUID sessionId) {
+        for (String room : rooms) {
+            join(room, sessionId);
+        }
+        storeFactory.pubSubStore().publish(PubSubType.BULK_JOIN, new BulkJoinLeaveMessage(sessionId, rooms, getName()));
+    }
+
     public void dispatch(String room, Packet packet) {
         Iterable<SocketIOClient> clients = getRoomClients(room);
 
@@ -320,6 +328,13 @@ public class Namespace implements SocketIONamespace {
     public void leaveRoom(String room, UUID sessionId) {
         leave(room, sessionId);
         storeFactory.pubSubStore().publish(PubSubType.LEAVE, new JoinLeaveMessage(sessionId, room, getName()));
+    }
+
+    public void leaveRooms(Set<String> rooms, final UUID sessionId) {
+        for (String room : rooms) {
+            leave(room, sessionId);
+        }
+        storeFactory.pubSubStore().publish(PubSubType.BULK_LEAVE, new BulkJoinLeaveMessage(sessionId, rooms, getName()));
     }
 
     private <K, V> void leave(ConcurrentMap<K, Set<V>> map, K room, V sessionId) {

--- a/src/main/java/com/corundumstudio/socketio/store/pubsub/BaseStoreFactory.java
+++ b/src/main/java/com/corundumstudio/socketio/store/pubsub/BaseStoreFactory.java
@@ -15,6 +15,8 @@
  */
 package com.corundumstudio.socketio.store.pubsub;
 
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +73,18 @@ public abstract class BaseStoreFactory implements StoreFactory {
             }
         }, JoinLeaveMessage.class);
 
+        pubSubStore().subscribe(PubSubType.BULK_JOIN, new PubSubListener<BulkJoinLeaveMessage>() {
+            @Override
+            public void onMessage(BulkJoinLeaveMessage msg) {
+                Set<String> rooms = msg.getRooms();
+
+                for (String room : rooms) {
+                    namespacesHub.get(msg.getNamespace()).join(room, msg.getSessionId());
+                }
+                log.debug("{} sessionId: {}", PubSubType.BULK_JOIN, msg.getSessionId());
+            }
+        }, BulkJoinLeaveMessage.class);
+
         pubSubStore().subscribe(PubSubType.LEAVE, new PubSubListener<JoinLeaveMessage>() {
             @Override
             public void onMessage(JoinLeaveMessage msg) {
@@ -80,6 +94,18 @@ public abstract class BaseStoreFactory implements StoreFactory {
                 log.debug("{} sessionId: {}", PubSubType.LEAVE, msg.getSessionId());
             }
         }, JoinLeaveMessage.class);
+
+        pubSubStore().subscribe(PubSubType.BULK_LEAVE, new PubSubListener<BulkJoinLeaveMessage>() {
+            @Override
+            public void onMessage(BulkJoinLeaveMessage msg) {
+                Set<String> rooms = msg.getRooms();
+
+                for (String room : rooms) {
+                    namespacesHub.get(msg.getNamespace()).leave(room, msg.getSessionId());
+                }
+                log.debug("{} sessionId: {}", PubSubType.BULK_LEAVE, msg.getSessionId());
+            }
+        }, BulkJoinLeaveMessage.class);
     }
 
     @Override

--- a/src/main/java/com/corundumstudio/socketio/store/pubsub/BulkJoinLeaveMessage.java
+++ b/src/main/java/com/corundumstudio/socketio/store/pubsub/BulkJoinLeaveMessage.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2012-2019 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.corundumstudio.socketio.store.pubsub;
+
+import java.util.Set;
+import java.util.UUID;
+
+public class BulkJoinLeaveMessage extends PubSubMessage {
+
+    private static final long serialVersionUID = 7506016762607624388L;
+
+    private UUID sessionId;
+    private String namespace;
+    private Set<String> rooms;
+
+    public BulkJoinLeaveMessage() {
+    }
+
+    public BulkJoinLeaveMessage(UUID id, Set<String> rooms, String namespace) {
+        super();
+        this.sessionId = id;
+        this.rooms = rooms;
+        this.namespace = namespace;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public UUID getSessionId() {
+        return sessionId;
+    }
+
+    public Set<String> getRooms() {
+        return rooms;
+    }
+
+}

--- a/src/main/java/com/corundumstudio/socketio/store/pubsub/PubSubType.java
+++ b/src/main/java/com/corundumstudio/socketio/store/pubsub/PubSubType.java
@@ -17,7 +17,7 @@ package com.corundumstudio.socketio.store.pubsub;
 
 public enum PubSubType {
 
-    CONNECT, DISCONNECT, JOIN, LEAVE, DISPATCH;
+    CONNECT, DISCONNECT, JOIN, BULK_JOIN, LEAVE, BULK_LEAVE, DISPATCH;
 
     @Override
     public String toString() {

--- a/src/main/java/com/corundumstudio/socketio/transport/NamespaceClient.java
+++ b/src/main/java/com/corundumstudio/socketio/transport/NamespaceClient.java
@@ -173,8 +173,18 @@ public class NamespaceClient implements SocketIOClient {
     }
 
     @Override
+    public void joinRooms(Set<String> rooms) {
+        namespace.joinRooms(rooms, getSessionId());
+    }
+
+    @Override
     public void leaveRoom(String room) {
         namespace.leaveRoom(room, getSessionId());
+    }
+
+    @Override
+    public void leaveRooms(Set<String> rooms) {
+        namespace.leaveRooms(rooms, getSessionId());
     }
 
     @Override


### PR DESCRIPTION
We have a large number of rooms a socket client can subscribe to, and when a client connects to our server, we pull all the rooms they were previously subscribed to from our backend and issue a join request for all the rooms, this also ends up issuing a publish on pubsub (async wrapper over RedissonPubSubStore in our case) for JOIN / LEAVE events 
This is causing high CPU spikes

Added a bulk JOIN / LEAVE API to allow the above use case to be handled in a more efficient manner for us. This will allow client to join a large number of rooms at the same time without causing a lot of resource strain