### PR TITLE
client support method isWritable(), avoid DirectByteBuffer oom

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
@@ -44,6 +44,13 @@ public interface SocketIOClient extends ClientOperations, Store {
     Transport getTransport();
 
     /**
+     * Returns true if and only if the I/O thread will perform the requested write operation immediately.
+     * Any write requests made when this method returns false are queued until the I/O thread is ready to process the queued write requests.
+     * @return
+     */
+    boolean isWritable();
+
+    /**
      * Send event with ack callback
      *
      * @param name - event name

--- a/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/ClientHead.java
@@ -289,4 +289,16 @@ public class ClientHead {
         return lastBinaryPacket;
     }
 
+    /**
+     * Returns true if and only if the I/O thread will perform the requested write operation immediately.
+     * Any write requests made when this method returns false are queued until the I/O thread is ready to process the queued write requests.
+     * @return
+     */
+    public boolean isWritable() {
+        TransportState state = channels.get(getCurrentTransport());
+        Channel channel = state.getChannel();
+        return channel != null && channel.isWritable();
+    }
+
+
 }

--- a/src/main/java/com/corundumstudio/socketio/transport/NamespaceClient.java
+++ b/src/main/java/com/corundumstudio/socketio/transport/NamespaceClient.java
@@ -89,6 +89,11 @@ public class NamespaceClient implements SocketIOClient {
     }
 
     @Override
+    public boolean isWritable() {
+        return isConnected() && this.baseClient.isWritable();
+    }
+
+    @Override
     public void send(Packet packet, AckCallback<?> ackCallback) {
         if (!isConnected()) {
             ackCallback.onTimeout();


### PR DESCRIPTION
socketIOClient support method isWritable(), avoid DirectByteBuffer oom when the channel is not writable.