### PR TITLE
fix WebSocketServerCompressionHandler is Not @Shareable

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
@@ -84,7 +84,6 @@ public class SocketIOChannelInitializer extends ChannelInitializer<Channel> impl
     private AuthorizeHandler authorizeHandler;
     private PollingTransport xhrPollingTransport;
     private WebSocketTransport webSocketTransport;
-    private WebSocketServerCompressionHandler webSocketTransportCompression = new WebSocketServerCompressionHandler();
     private EncoderHandler encoderHandler;
     private WrongUrlHandler wrongUrlHandler;
 
@@ -187,9 +186,8 @@ public class SocketIOChannelInitializer extends ChannelInitializer<Channel> impl
 
         pipeline.addLast(AUTHORIZE_HANDLER, authorizeHandler);
         pipeline.addLast(XHR_POLLING_TRANSPORT, xhrPollingTransport);
-        // TODO use single instance when https://github.com/netty/netty/issues/4755 will be resolved
         if (configuration.isWebsocketCompression()) {
-            pipeline.addLast(WEB_SOCKET_TRANSPORT_COMPRESSION, webSocketTransportCompression);
+            pipeline.addLast(WEB_SOCKET_TRANSPORT_COMPRESSION, new WebSocketServerCompressionHandler());
         }
         pipeline.addLast(WEB_SOCKET_TRANSPORT, webSocketTransport);
 


### PR DESCRIPTION
for  https://github.com/netty/netty/issues/4755, it solved WebSockeClientCompressionHandler become @Shareable.
but SocketioServer actually using WebSocketServerCompressionHandler, it is not  @Shareable.
current 1.7.24 casue following error：
ChannelInitializer  Failed to initialize a channel. Closing: [id: 0x891592f8, L:/[:8080](http://:8080/) - R:/[:63558](http://:63558/)]
 io.netty.channel.ChannelPipelineException: io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler is not a @Sharable handler, so can't be added or removed multiple times.