### PR TITLE
[DRAFT] Provide Support for Socket IO Protocol V5

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/handler/AuthorizeHandler.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/AuthorizeHandler.java
@@ -265,7 +265,7 @@ public class AuthorizeHandler extends ChannelInboundHandlerAdapter implements Di
     public void connect(ClientHead client) {
         Namespace ns = namespacesHub.get(Namespace.DEFAULT_NAME);
 
-        if (!client.getNamespaces().contains(ns)) {
+        if (!EngineIOVersion.V4.equals(client.getEngineIOVersion()) && !client.getNamespaces().contains(ns)) {
             Packet packet = new Packet(PacketType.MESSAGE, client.getEngineIOVersion());
             packet.setSubType(PacketType.CONNECT);
             if (EngineIOVersion.V4.equals(client.getEngineIOVersion())) {


### PR DESCRIPTION
Hello, I'm planning to use Netty Socket IO server in production but was unable to use it with the official javascript client due to not supporting protocol version 5 of Socket IO. I didn't knew it didn't support it until I tested the namespace connect event not being fired on the client side. I was quite shocked this library exists since 2013 and the Socket IO don't have it referenced in the language SDKs list.

I'm writing this PR as a draft to get a permission from the author of the repository @mrniko to continue writing the patch for this PR.

The checklist for this PR to keep things clear and easy to track:
- [x] 8cbf883949b52326c381d176b1db9cecf54ee262 ~remove the implicit connection to the default namespace~ (Ref: https://github.com/socketio/socket.io/commit/09b6f2333950b8afc8c1400b504b01ad757876bd)
- [ ] rename `ERROR` to `CONNECT_ERROR` (Ref: https://github.com/socketio/socket.io/commit/d16c035d258b8deb138f71801cb5aeedcdb3f002)
- [ ] the `CONNECT` packet now can contain a payload (Ref: https://github.com/socketio/socket.io/commit/2875d2cfdfa463e64cb520099749f543bbc4eb15)
- [ ] the payload `CONNECT_ERROR` packet is now an object instead of a plain string (Ref: https://github.com/socketio/socket.io/commit/54bf4a44e9e896dfb64764ee7bd4e8823eb7dc7b)

- [ ] (Optional) Patching the server to bypass the test-suite test provided by the official Socket IO protocol. [Ref](https://github.com/socketio/socket.io-protocol/tree/main#test-suite)

[Source](https://github.com/socketio/socket.io-protocol/tree/main#difference-between-v5-and-v4)

Thank you for your time reading and checking this PR out and have a great day.
God knows best.