### PR TITLE
fix attachment lose #900

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/BroadcastOperations.java
+++ b/src/main/java/com/corundumstudio/socketio/BroadcastOperations.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2012-2019 Nikita Koksharov
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/corundumstudio/socketio/ClientOperations.java
+++ b/src/main/java/com/corundumstudio/socketio/ClientOperations.java
@@ -27,6 +27,12 @@ public interface ClientOperations {
      * Send custom packet.
      * But {@link ClientOperations#sendEvent} method
      * usage is enough for most cases.
+     * {@link Packet#attachments} needs to be filled when sending byte[].
+     * Using {@link io.netty.buffer.Unpooled#wrappedBuffer(byte[])} to
+     * fill byte[] into {@link Packet#attachments} is the recommended way.
+     * Before using {@link Packet#addAttachment(io.netty.buffer.ByteBuf)},
+     * be sure to initialize the number of attachments with
+     * {@link Packet#initAttachments(int)})}
      *
      * @param packet - packet to send
      */

--- a/src/main/java/com/corundumstudio/socketio/SingleRoomBroadcastOperations.java
+++ b/src/main/java/com/corundumstudio/socketio/SingleRoomBroadcastOperations.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (c) 2012-2019 Nikita Koksharov
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,9 +22,14 @@ import com.corundumstudio.socketio.protocol.PacketType;
 import com.corundumstudio.socketio.store.StoreFactory;
 import com.corundumstudio.socketio.store.pubsub.DispatchMessage;
 import com.corundumstudio.socketio.store.pubsub.PubSubType;
+import io.netty.buffer.Unpooled;
+import org.springframework.lang.NonNull;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Author: liangjiaqi
@@ -97,11 +102,24 @@ public class SingleRoomBroadcastOperations implements BroadcastOperations {
     }
 
     @Override
-    public void sendEvent(String name, Object... data) {
+    public void sendEvent(String name, @NonNull Object... data) {
         Packet packet = new Packet(PacketType.MESSAGE, EngineIOVersion.UNKNOWN);
         packet.setSubType(PacketType.EVENT);
         packet.setName(name);
         packet.setData(Arrays.asList(data));
+
+        // handle byte[] data
+        List<byte[]> bytes = Arrays.stream(data)
+                .filter(o -> o instanceof byte[])
+                .map(b -> (byte[]) b)
+                .filter(b -> b.length > 0)
+                .collect(Collectors.toList());
+
+        if (!CollectionUtils.isEmpty(bytes)) {
+            packet.initAttachments(bytes.size());
+            bytes.stream().peek(b -> packet.addAttachment(Unpooled.wrappedBuffer(b)));
+        }
+
         send(packet);
     }
 

--- a/src/main/java/com/corundumstudio/socketio/handler/EncoderHandler.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/EncoderHandler.java
@@ -259,7 +259,7 @@ public class EncoderHandler extends ChannelOutboundHandlerAdapter {
             for (ByteBuf buf : packet.getAttachments()) {
                 ByteBuf outBuf = encoder.allocateBuffer(ctx.alloc());
                 outBuf.writeByte(4);
-                outBuf.writeBytes(buf);
+                outBuf.writeBytes(buf, 0, buf.readableBytes());
                 if (log.isTraceEnabled()) {
                     log.trace("Out attachment: {} sessionId: {}", ByteBufUtil.hexDump(outBuf), msg.getSessionId());
                 }

--- a/src/main/java/com/corundumstudio/socketio/protocol/Packet.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/Packet.java
@@ -15,14 +15,13 @@
  */
 package com.corundumstudio.socketio.protocol;
 
+import com.corundumstudio.socketio.namespace.Namespace;
 import io.netty.buffer.ByteBuf;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import com.corundumstudio.socketio.namespace.Namespace;
 
 public class Packet implements Serializable {
 
@@ -71,9 +70,9 @@ public class Packet implements Serializable {
 
     /**
      * Get packet data
-     * 
+     *
      * @param <T> the type data
-     * 
+     *
      * <pre>
      * @return <b>json object</b> for PacketType.JSON type
      * <b>message</b> for PacketType.MESSAGE type
@@ -145,6 +144,16 @@ public class Packet implements Serializable {
         this.attachmentsCount = attachmentsCount;
         this.attachments = new ArrayList<ByteBuf>(attachmentsCount);
     }
+
+    /**
+     *
+     * It needs to be called when transferring the byte[].
+     * Recommended Use{@link io.netty.buffer.Unpooled#wrappedBuffer(byte[])}.
+     * Before using {@link #addAttachment(ByteBuf)},
+     * be sure to initialize the number of attachments with {@link #initAttachments(int)})}
+     *
+     * @param attachment
+     */
     public void addAttachment(ByteBuf attachment) {
         if (this.attachments.size() < attachmentsCount) {
             this.attachments.add(attachment);

--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketEncoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketEncoder.java
@@ -277,10 +277,6 @@ public class PacketEncoder {
                         jsonSupport.writeValue(out, values);
 
                         if (!jsonSupport.getArrays().isEmpty()) {
-                            packet.initAttachments(jsonSupport.getArrays().size());
-                            for (byte[] array : jsonSupport.getArrays()) {
-                                packet.addAttachment(Unpooled.wrappedBuffer(array));
-                            }
                             packet.setSubType(packet.getSubType() == PacketType.ACK
                                     ? PacketType.BINARY_ACK : PacketType.BINARY_EVENT);
                         }


### PR DESCRIPTION
Fix the problem that when broadcasting a byte array data to multiple clients in the same room, the client receives 450, 452 and other wrong binaryEvent number messages and has 45x probe header messages but loses attaments