### PR TITLE
Add more Socket.IO v3/v4 features: auth data, multi-packet separator

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/AuthTokenListener.java
+++ b/src/main/java/com/corundumstudio/socketio/AuthTokenListener.java
@@ -1,0 +1,14 @@
+package com.corundumstudio.socketio;
+
+public interface AuthTokenListener {
+
+  /** Socket.IO clients from version 4 can offer an auth token when connecting
+   * to a namespace. This listener gets invoked if a token is found in the connect
+   * packet
+   * @param authToken the token as parsed by the JSON parser
+   * @param client client that is connecting
+   * @return authorization result
+   */
+  AuthTokenResult getAuthTokenResult(Object authToken, SocketIOClient client);
+
+}

--- a/src/main/java/com/corundumstudio/socketio/AuthTokenListener.java
+++ b/src/main/java/com/corundumstudio/socketio/AuthTokenListener.java
@@ -1,5 +1,21 @@
 package com.corundumstudio.socketio;
 
+/**
+ * Copyright (c) 2012-2023 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 public interface AuthTokenListener {
 
   /** Socket.IO clients from version 4 can offer an auth token when connecting

--- a/src/main/java/com/corundumstudio/socketio/AuthTokenResult.java
+++ b/src/main/java/com/corundumstudio/socketio/AuthTokenResult.java
@@ -1,7 +1,22 @@
 package com.corundumstudio.socketio;
 
-public class AuthTokenResult {
+/**
+ * Copyright (c) 2012-2023 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+public class AuthTokenResult {
 
   public final static AuthTokenResult AuthTokenResultSuccess = new AuthTokenResult(true, null);
   private final boolean success;

--- a/src/main/java/com/corundumstudio/socketio/AuthTokenResult.java
+++ b/src/main/java/com/corundumstudio/socketio/AuthTokenResult.java
@@ -1,0 +1,22 @@
+package com.corundumstudio.socketio;
+
+public class AuthTokenResult {
+
+
+  public final static AuthTokenResult AuthTokenResultSuccess = new AuthTokenResult(true, null);
+  private final boolean success;
+  private final Object errorData;
+
+  public AuthTokenResult(final boolean success, final Object errorData) {
+    this.success = success;
+    this.errorData = errorData;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public Object getErrorData() {
+    return errorData;
+  }
+}

--- a/src/main/java/com/corundumstudio/socketio/AuthorizationListener.java
+++ b/src/main/java/com/corundumstudio/socketio/AuthorizationListener.java
@@ -18,8 +18,8 @@ package com.corundumstudio.socketio;
 public interface AuthorizationListener {
 
     /**
-     * Checks whether a client with handshake data is authorized.
-	 * Optionally returns storeParams that will be added to {@link SocketIOClient} store
+     * Checks whether a client with handshake data is authorized on connection
+	   * Optionally returns storeParams that will be added to {@link SocketIOClient} store
      *
      * @param data handshake data
      * @return - {@link AuthorizationResult}

--- a/src/main/java/com/corundumstudio/socketio/HandshakeData.java
+++ b/src/main/java/com/corundumstudio/socketio/HandshakeData.java
@@ -34,6 +34,7 @@ public class HandshakeData implements Serializable {
     private String url;
     private Map<String, List<String>> urlParams;
     private boolean xdomain;
+    private Object authToken;
 
     // needed for correct deserialization
     public HandshakeData() {
@@ -119,4 +120,11 @@ public class HandshakeData implements Serializable {
         return null;
     }
 
+    public void setAuthToken(Object token) {
+        this.authToken = token;
+    }
+
+    public Object getAuthToken() {
+        return this.authToken;
+    }
 }

--- a/src/main/java/com/corundumstudio/socketio/SocketIONamespace.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIONamespace.java
@@ -49,4 +49,5 @@ public interface SocketIONamespace extends ClientListeners {
      */
     SocketIOClient getClient(UUID uuid);
 
+    void addAuthTokenListener(AuthTokenListener listener);
 }

--- a/src/main/java/com/corundumstudio/socketio/handler/EncoderHandler.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/EncoderHandler.java
@@ -15,18 +15,35 @@
  */
 package com.corundumstudio.socketio.handler;
 
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
 import com.corundumstudio.socketio.Configuration;
 import com.corundumstudio.socketio.Transport;
+import com.corundumstudio.socketio.messages.HttpErrorMessage;
 import com.corundumstudio.socketio.messages.HttpMessage;
-import com.corundumstudio.socketio.messages.*;
+import com.corundumstudio.socketio.messages.OutPacketMessage;
+import com.corundumstudio.socketio.messages.XHROptionsMessage;
+import com.corundumstudio.socketio.messages.XHRPostMessage;
 import com.corundumstudio.socketio.protocol.Packet;
 import com.corundumstudio.socketio.protocol.PacketEncoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.channel.*;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.handler.codec.http.*;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
@@ -36,9 +53,6 @@ import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -47,8 +61,8 @@ import java.util.List;
 import java.util.Queue;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Sharable
 public class EncoderHandler extends ChannelOutboundHandlerAdapter {

--- a/src/main/java/com/corundumstudio/socketio/listener/DefaultExceptionListener.java
+++ b/src/main/java/com/corundumstudio/socketio/listener/DefaultExceptionListener.java
@@ -59,4 +59,9 @@ public class DefaultExceptionListener extends ExceptionListenerAdapter {
         return true;
     }
 
+    @Override
+    public void onAuthException(Throwable e, SocketIOClient client) {
+        log.error(e.getMessage(), e);
+    }
+
 }

--- a/src/main/java/com/corundumstudio/socketio/listener/ExceptionListener.java
+++ b/src/main/java/com/corundumstudio/socketio/listener/ExceptionListener.java
@@ -36,4 +36,5 @@ public interface ExceptionListener {
 
     boolean exceptionCaught(ChannelHandlerContext ctx, Throwable e) throws Exception;
 
+    void onAuthException(Throwable e, SocketIOClient client);
 }


### PR DESCRIPTION
This PR adds support for the [auth data feature](https://socket.io/docs/v4/middlewares/#sending-credentials) in Socket.IO v3.  I would have preferred to fold this into the current AuthorizationListener but they activate at different times in the connection lifetime and I didn't feel comfortable making these deep changes without aligning first.

The current implementation allows reading the auth data and then updating the client. Since this is only available for namespaces I have added the listener only to SocketIONamespace and not ClientListeners.

This also fixes the connection_error data read error when Socket IO v3/4 expect multiple packets in one. There is a delimiter char \x1e that is expected as a separator when multiple packets are sent in one response: https://socket.io/docs/v4/socket-io-protocol/#sample-session

I'm not sure if I've adapted all protocol changes that came after v2 like the removal of msgpack (see https://github.com/socketio/socket.io-parser/commit/299849b00294c3bc95817572441f3aca8ffb1f65), reviews would be appreciated.

This code has been tested against JS socket-io.client 4.7.2 using auth tokens.