### PR TITLE
Only remove first time handshake failures

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/transport/WebSocketTransport.java
+++ b/src/main/java/com/corundumstudio/socketio/transport/WebSocketTransport.java
@@ -183,8 +183,11 @@ public class WebSocketTransport extends ChannelInboundHandlerAdapter {
         } catch (Throwable t) {
             log.warn("Can't close channel for sessionId: {}", sessionId, t);
         }
-        ClientHead clientHead = clientsBox.removeClient(sessionId);
-        clientHead.disconnect();
+        ClientHead clientHead = clientsBox.get(sessionId);
+        if (clientHead != null && clientHead.getNamespaces().isEmpty()) {
+        	clientsBox.removeClient(sessionId);
+        	clientHead.disconnect();
+    	}
         log.info("Client with sessionId: {} was disconnected", sessionId);
     }
 


### PR DESCRIPTION
Proposed tweak to #987 in order to allow future reconnections in case of recoverable handshake failure