### PR TITLE
io.netty.handler.codec.http.TooLongHttpLineException: An HTTP line is larger than 4096 bytes.

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/Configuration.java
+++ b/src/main/java/com/corundumstudio/socketio/Configuration.java
@@ -25,6 +25,7 @@ import com.corundumstudio.socketio.listener.ExceptionListener;
 import com.corundumstudio.socketio.protocol.JsonSupport;
 import com.corundumstudio.socketio.store.MemoryStoreFactory;
 import com.corundumstudio.socketio.store.StoreFactory;
+import io.netty.handler.codec.http.HttpDecoderConfig;
 
 import javax.net.ssl.KeyManagerFactory;
 
@@ -91,6 +92,8 @@ public class Configuration {
     private boolean randomSession = false;
 
     private boolean needClientAuth = false;
+
+    private HttpRequestDecoderConfiguration httpRequestDecoderConfiguration = new HttpRequestDecoderConfiguration();
 
     public Configuration() {
     }
@@ -161,6 +164,7 @@ public class Configuration {
         setWebsocketCompression(conf.isWebsocketCompression());
         setRandomSession(conf.randomSession);
         setNeedClientAuth(conf.isNeedClientAuth());
+        setHttpRequestDecoderConfiguration(conf.getHttpRequestDecoderConfiguration());
     }
 
     public JsonSupport getJsonSupport() {
@@ -617,5 +621,20 @@ public class Configuration {
     }
     public boolean isNeedClientAuth() {
         return needClientAuth;
+    }
+
+    public HttpRequestDecoderConfiguration getHttpRequestDecoderConfiguration() {
+        return httpRequestDecoderConfiguration;
+    }
+
+    public void setHttpRequestDecoderConfiguration(HttpRequestDecoderConfiguration httpRequestDecoderConfiguration) {
+        this.httpRequestDecoderConfiguration = httpRequestDecoderConfiguration;
+    }
+
+    public HttpDecoderConfig getHttpDecoderConfig() {
+        return new HttpDecoderConfig()
+                .setMaxInitialLineLength(httpRequestDecoderConfiguration.getMaxInitialLineLength())
+                .setMaxHeaderSize(httpRequestDecoderConfiguration.getMaxHeaderSize())
+                .setMaxChunkSize(httpRequestDecoderConfiguration.getMaxChunkSize());
     }
 }

--- a/src/main/java/com/corundumstudio/socketio/HttpRequestDecoderConfiguration.java
+++ b/src/main/java/com/corundumstudio/socketio/HttpRequestDecoderConfiguration.java
@@ -1,0 +1,42 @@
+package com.corundumstudio.socketio;
+
+public class HttpRequestDecoderConfiguration {
+
+    private int maxInitialLineLength;
+    private int maxHeaderSize;
+    private int maxChunkSize;
+
+    public HttpRequestDecoderConfiguration(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
+        this.maxInitialLineLength = maxInitialLineLength;
+        this.maxHeaderSize = maxHeaderSize;
+        this.maxChunkSize = maxChunkSize;
+    }
+
+    public HttpRequestDecoderConfiguration() {
+        this(4096, 8192, 8192);
+    }
+
+    public int getMaxInitialLineLength() {
+        return maxInitialLineLength;
+    }
+
+    public void setMaxInitialLineLength(int maxInitialLineLength) {
+        this.maxInitialLineLength = maxInitialLineLength;
+    }
+
+    public int getMaxHeaderSize() {
+        return maxHeaderSize;
+    }
+
+    public void setMaxHeaderSize(int maxHeaderSize) {
+        this.maxHeaderSize = maxHeaderSize;
+    }
+
+    public int getMaxChunkSize() {
+        return maxChunkSize;
+    }
+
+    public void setMaxChunkSize(int maxChunkSize) {
+        this.maxChunkSize = maxChunkSize;
+    }
+}

--- a/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOChannelInitializer.java
@@ -167,7 +167,7 @@ public class SocketIOChannelInitializer extends ChannelInitializer<Channel> impl
      * @param pipeline - channel pipeline
      */
     protected void addSocketioHandlers(ChannelPipeline pipeline) {
-        pipeline.addLast(HTTP_REQUEST_DECODER, new HttpRequestDecoder());
+        pipeline.addLast(HTTP_REQUEST_DECODER, new HttpRequestDecoder(configuration.getHttpDecoderConfig()));
         pipeline.addLast(HTTP_AGGREGATOR, new HttpObjectAggregator(configuration.getMaxHttpContentLength()) {
             @Override
             protected Object newContinueResponse(HttpMessage start, int maxContentLength,


### PR DESCRIPTION
This PR contains http request decoder configuration

Resolves: #1003