### PR TITLE
fix(namespace): Avoid repeated calls to the onConnect method

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/handler/AuthorizeHandler.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/AuthorizeHandler.java
@@ -281,7 +281,9 @@ public class AuthorizeHandler extends ChannelInboundHandlerAdapter implements Di
             configuration.getStoreFactory().pubSubStore().publish(PubSubType.CONNECT, new ConnectMessage(client.getSessionId()));
 
             SocketIOClient nsClient = client.addNamespaceClient(ns);
-            ns.onConnect(nsClient);
+            if (!ns.getAllClients().contains(nsClient)) {
+                ns.onConnect(nsClient);
+            }
         }
     }
 

--- a/src/main/java/com/corundumstudio/socketio/handler/PacketListener.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/PacketListener.java
@@ -92,7 +92,9 @@ public class PacketListener {
 
             if (packet.getSubType() == PacketType.CONNECT) {
                 Namespace namespace = namespacesHub.get(packet.getNsp());
-                namespace.onConnect(client);
+                if (!namespace.getAllClients().contains(client)) {
+                    namespace.onConnect(client);
+                }
                 // send connect handshake packet back to client
                 if (!EngineIOVersion.V4.equals(client.getEngineIOVersion())) {
                     client.getBaseClient().send(packet, transport);


### PR DESCRIPTION
- Add checks in AuthorizeHandler and PacketListener to ensure that onConnect is called only once per client
- Perform this check for the SocketIOClient and Namespace objects
- This modification prevents potential problems caused by duplicate connections