### PR TITLE
fix(namespace): prevents the client from repeatedly connecting to the namespace

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
+++ b/src/main/java/com/corundumstudio/socketio/namespace/Namespace.java
@@ -200,6 +200,11 @@ public class Namespace implements SocketIONamespace {
     }
 
     public void onConnect(SocketIOClient client) {
+        if (roomClients.containsKey(getName()) &&
+                roomClients.get(getName()).contains(client.getSessionId())) {
+            return;
+        }
+
         join(getName(), client.getSessionId());
         storeFactory.pubSubStore().publish(PubSubType.JOIN, new JoinLeaveMessage(client.getSessionId(), getName(), getName()));
 


### PR DESCRIPTION
- Add a check to the onConnect method to prevent clients from joining the same namespace twice
- Optimized namespace connection logic to improve system stability