### PR TITLE
Fixed a problem that connection from Socket.IO Client v2 failed.

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
@@ -307,23 +307,18 @@ public class PacketDecoder {
          */
         ByteBuf buffer = frame.slice();
 
+        int namespaceFieldEndIndex = buffer.bytesBefore((byte) ',');
+        namespaceFieldEndIndex = namespaceFieldEndIndex > 0 ? namespaceFieldEndIndex : buffer.readableBytes();
 
-        int endIndex = buffer.bytesBefore((byte) '?');
-        if (endIndex > 0) {
-            String namespace = readString(buffer, endIndex);
-            if(namespace.startsWith("/")) {
-                frame.skipBytes(endIndex + 1);
-                return namespace;
-            }
+        int namespaceEndIndex = buffer.bytesBefore((byte) '?');
+        namespaceEndIndex = namespaceEndIndex > 0 ? namespaceEndIndex : namespaceFieldEndIndex;
+
+        String namespace = readString(buffer, namespaceEndIndex);
+        if (namespace.startsWith("/")) {
+            frame.skipBytes(namespaceFieldEndIndex + 1);
+            return namespace;
         }
-        endIndex = buffer.bytesBefore((byte) ',');
-        if (endIndex > 0) {
-            String namespace = readString(buffer, endIndex);
-            if(namespace.startsWith("/")) {
-                frame.skipBytes(endIndex + 1);
-                return namespace;
-            }
-        }
+
         if (defaultToAll) {
             // skip this frame
             frame.skipBytes(frame.readableBytes());


### PR DESCRIPTION
Fixed a problem that connection from Socket.IO Client v2 failed.

The cause is an error in the skip range of the index of the frame. It appears to have been introduced during the change between versions 2.0.9 and 2.0.11.

If there is no problem, please merge.
