### PR TITLE
修复触发两次连接，但是前一次是无法获取到authToken的

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/handler/AuthorizeHandler.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/AuthorizeHandler.java
@@ -281,7 +281,7 @@ public class AuthorizeHandler extends ChannelInboundHandlerAdapter implements Di
             configuration.getStoreFactory().pubSubStore().publish(PubSubType.CONNECT, new ConnectMessage(client.getSessionId()));
 
             SocketIOClient nsClient = client.addNamespaceClient(ns);
-            ns.onConnect(nsClient);
+            // ns.onConnect(nsClient);
         }
     }
 


### PR DESCRIPTION
[https://github.com/mrniko/netty-socketio/issues/983](#983 )
The fix triggers two connections, but the first one fails to obtain the authToken