### PR TITLE
Try namespace if /namespace not found

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/handler/InPacketHandler.java
+++ b/src/main/java/com/corundumstudio/socketio/handler/InPacketHandler.java
@@ -65,7 +65,11 @@ public class InPacketHandler extends SimpleChannelInboundHandler<PacketsMessage>
             try {
                 Packet packet = decoder.decodePackets(content, client);
 
-                Namespace ns = namespacesHub.get(packet.getNsp());
+                String namespace = packet.getNsp();
+                Namespace ns = namespacesHub.get(namespace);
+                if (ns == null && namespace.charAt(0) == '/') 
+                	ns = namespacesHub.get(namespace.substring(1));
+                	
                 if (ns == null) {
                     if (packet.getSubType() == PacketType.CONNECT) {
                         Packet p = new Packet(PacketType.MESSAGE, client.getEngineIOVersion());


### PR DESCRIPTION

Proposed fix to #1023: the idea is to try and get the packet namespace first, and then try finding a namespace without the leading "/"

