### PR TITLE
Support for v1 / readNamespace. V1 namespace is without special characters

### DIFF
--- a/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
+++ b/src/main/java/com/corundumstudio/socketio/protocol/PacketDecoder.java
@@ -302,20 +302,31 @@ public class PacketDecoder {
 
         /**
          * namespace post request with url queryString, like
-         *  /message?a=1,
-         *  /message,
+         *  /message (v1)
+         *  /message?a=1, (v2)
+         *  /message, (v3,v4)
          */
         ByteBuf buffer = frame.slice();
 
+        boolean withSpecialChar = false;
+
         int namespaceFieldEndIndex = buffer.bytesBefore((byte) ',');
-        namespaceFieldEndIndex = namespaceFieldEndIndex > 0 ? namespaceFieldEndIndex : buffer.readableBytes();
+        if (namespaceFieldEndIndex > 0) {
+            withSpecialChar = true;
+        } else {
+            namespaceFieldEndIndex = buffer.readableBytes();
+        }
 
         int namespaceEndIndex = buffer.bytesBefore((byte) '?');
-        namespaceEndIndex = namespaceEndIndex > 0 ? namespaceEndIndex : namespaceFieldEndIndex;
+        if (namespaceEndIndex > 0) {
+            withSpecialChar = true;
+        } else {
+            namespaceEndIndex = namespaceFieldEndIndex;
+        }
 
         String namespace = readString(buffer, namespaceEndIndex);
         if (namespace.startsWith("/")) {
-            frame.skipBytes(namespaceFieldEndIndex + 1);
+            frame.skipBytes(namespaceFieldEndIndex + (withSpecialChar ? 1 : 0));
             return namespace;
         }
 


### PR DESCRIPTION
In PR https://github.com/mrniko/netty-socketio/pull/1020 @penguinlab added support for version v2.
I added support for v1 method **readNamespace**. Connect message is without comma. Only slash and namespace: for example: "/chat".